### PR TITLE
resource name regex validation

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "name" {
   type        = string
   description = "The name of the Key Vault."
   validation {
-    condition     = can(regex("^[a-zA-Z][a-zA-Z0-9-]{1,22}[a-zA-Z0-9]$", var.name) && index(var.name, "--") == -1)
+    condition     = can(regex("^[a-zA-Z][a-zA-Z0-9-]{1,22}[a-zA-Z0-9]$", var.name)) && index(var.name, "--") == -1
     error_message = "The name must be between 3 and 24 characters long.  Valid characters are alphanumerics and hyphens.  The name must start with a letter, end with a letter or digit, and can't contain consecutive hyphens."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "name" {
   type        = string
   description = "The name of the Key Vault."
   validation {
-    condition     = can(regex("^[a-zA-Z][a-zA-Z0-9-]{1,22}[a-zA-Z0-9]$", var.name)) && index(var.name, "--") == -1
+    condition     = can(regex("^[a-zA-Z][a-zA-Z0-9-]{1,22}[a-zA-Z0-9]$", var.name)) && !strcontains(var.name, "--")
     error_message = "The name must be between 3 and 24 characters long.  Valid characters are alphanumerics and hyphens.  The name must start with a letter, end with a letter or digit, and can't contain consecutive hyphens."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "name" {
   type        = string
   description = "The name of the Key Vault."
   validation {
-    condition     = can(regex("^(?=.{3,24}$)(?!.*--)[a-zA-Z][a-zA-Z0-9-]+[a-zA-Z0-9]$", var.name))
+    condition     = can(regex("^[a-zA-Z][a-zA-Z0-9-]{1,22}[a-zA-Z0-9]$", var.name) && index(var.name, "--") == -1)
     error_message = "The name must be between 3 and 24 characters long.  Valid characters are alphanumerics and hyphens.  The name must start with a letter, end with a letter or digit, and can't contain consecutive hyphens."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -18,8 +18,8 @@ variable "name" {
   type        = string
   description = "The name of the Key Vault."
   validation {
-    condition     = can(regex("^[a-z0-9-]{3,24}$", var.name))
-    error_message = "The name must be between 3 and 24 characters long and can only contain lowercase letters, numbers and dashes."
+    condition     = can(regex("^(?=.{3,24}$)(?!.*--)[a-zA-Z][a-zA-Z0-9-]+[a-zA-Z0-9]$", var.name))
+    error_message = "The name must be between 3 and 24 characters long.  Valid characters are alphanumerics and hyphens.  The name must start with a letter, end with a letter or digit, and can't contain consecutive hyphens."
   }
 }
 


### PR DESCRIPTION
this improves the name regex for Key Vault

this initial syntax was used, which is valid, but terraform validate doesn't understand the opening part:

```regex
^(?=.{3,24}$)(?!.*--)[a-zA-Z][a-zA-Z0-9-]+[a-zA-Z0-9]$
```

so instead a combination of a regex & a check for double hyphens is used.