### PR TITLE
feat: Align to WAF - `public_network_access_enabled` set to `false` (breaking change)

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -59,7 +59,7 @@ DESCRIPTION
 variable "public_network_access_enabled" {
   type        = bool
   description = "Specifies whether public access is permitted."
-  default     = true
+  default     = false
 }
 
 variable "enabled_for_disk_encryption" {


### PR DESCRIPTION
This pull request includes a change to the `variables.tf` file. The default value of the `public_network_access_enabled` variable has been switched from `true` to `false`, which means public access is not permitted by default now.

This is to align to WAF best practices