### PR TITLE
The attribute principal_type for role assigments

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ Default: `{}`
 
 ### <a name="input_enable_telemetry"></a> [enable\_telemetry](#input\_enable\_telemetry)
 
-Description: This variable controls whether or not telemetry is enabled for the module.  
-For more information see https://aka.ms/avm/telemetryinfo.  
+Description: This variable controls whether or not telemetry is enabled for the module.
+For more information see https://aka.ms/avm/telemetryinfo.
 If it is set to false, then no telemetry will be collected.
 
 Type: `bool`
@@ -200,6 +200,7 @@ map(object({
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string
+      principal_type                         = optional(string, "ServicePrincipal")
       description                            = optional(string, null)
       skip_service_principal_aad_check       = optional(bool, false)
       condition                              = optional(string, null)
@@ -237,8 +238,8 @@ Default: `{}`
 
 ### <a name="input_network_acls"></a> [network\_acls](#input\_network\_acls)
 
-Description: The network ACL configuration for the Key Vault.  
-If not specified then the Key Vault will be created with a firewall that blocks access.  
+Description: The network ACL configuration for the Key Vault.
+If not specified then the Key Vault will be created with a firewall that blocks access.
 Specify `null` to create the Key Vault with no firewall.
 
 - `bypass` - (Optional) Should Azure Services bypass the ACL. Possible values are `AzureServices` and `None`. Defaults to `None`.
@@ -287,6 +288,7 @@ map(object({
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string
+      principal_type                         = optional(string, "ServicePrincipal")
       description                            = optional(string, null)
       skip_service_principal_aad_check       = optional(bool, false)
       condition                              = optional(string, null)
@@ -337,6 +339,7 @@ Description: A map of role assignments to create on the Key Vault. The map key i
 
 - `role_definition_id_or_name` - The ID or name of the role definition to assign to the principal.
 - `principal_id` - The ID of the principal to assign the role to.
+- `principal_type` - The type of the `principal_id`. Possible values are `User`, `Group` and `ServicePrincipal`. Changing this forces a new resource to be created.
 - `description` - The description of the role assignment.
 - `skip_service_principal_aad_check` - If set to true, skips the Azure Active Directory check for the service principal in the tenant. Defaults to false.
 - `condition` - The condition which will be used to scope the role assignment.
@@ -350,6 +353,7 @@ Type:
 map(object({
     role_definition_id_or_name             = string
     principal_id                           = string
+    principal_type                         = optional(string, "ServicePrincipal")
     description                            = optional(string, null)
     skip_service_principal_aad_check       = optional(bool, false)
     condition                              = optional(string, null)
@@ -387,6 +391,7 @@ map(object({
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string
+      principal_type                         = optional(string, "ServicePrincipal")
       description                            = optional(string, null)
       skip_service_principal_aad_check       = optional(bool, false)
       condition                              = optional(string, null)
@@ -400,8 +405,8 @@ Default: `{}`
 
 ### <a name="input_secrets_value"></a> [secrets\_value](#input\_secrets\_value)
 
-Description: A map of secret keys to values.  
-The map key is the supplied input to `var.secrets`.  
+Description: A map of secret keys to values.
+The map key is the supplied input to `var.secrets`.
 The map value is the secret value.
 
 This is a separate variable to `var.secrets` because it is sensitive and therefore cannot be used in a `for_each` loop.
@@ -436,9 +441,9 @@ Default: `null`
 
 ### <a name="input_wait_for_rbac_before_key_operations"></a> [wait\_for\_rbac\_before\_key\_operations](#input\_wait\_for\_rbac\_before\_key\_operations)
 
-Description: This variable controls the amount of time to wait before performing key operations.  
-It only applies when `var.role_assignments` and `var.keys` are both set.  
-This is useful when you are creating role assignments on the key vault and immediately creating keys in it.  
+Description: This variable controls the amount of time to wait before performing key operations.
+It only applies when `var.role_assignments` and `var.keys` are both set.
+This is useful when you are creating role assignments on the key vault and immediately creating keys in it.
 The default is 30 seconds for create and 0 seconds for destroy.
 
 Type:
@@ -454,9 +459,9 @@ Default: `{}`
 
 ### <a name="input_wait_for_rbac_before_secret_operations"></a> [wait\_for\_rbac\_before\_secret\_operations](#input\_wait\_for\_rbac\_before\_secret\_operations)
 
-Description: This variable controls the amount of time to wait before performing secret operations.  
-It only applies when `var.role_assignments` and `var.secrets` are both set.  
-This is useful when you are creating role assignments on the key vault and immediately creating secrets in it.  
+Description: This variable controls the amount of time to wait before performing secret operations.
+It only applies when `var.role_assignments` and `var.secrets` are both set.
+This is useful when you are creating role assignments on the key vault and immediately creating secrets in it.
 The default is 30 seconds for create and 0 seconds for destroy.
 
 Type:

--- a/main.keys.tf
+++ b/main.keys.tf
@@ -36,6 +36,7 @@ resource "azurerm_role_assignment" "keys" {
   for_each = local.keys_role_assignments
 
   principal_id                           = each.value.role_assignment.principal_id
+  principal_type                         = each.value.role_assignment.principal_type
   scope                                  = azurerm_key_vault_key.this[each.value.key_key].resource_versionless_id
   condition                              = each.value.role_assignment.condition
   condition_version                      = each.value.role_assignment.condition_version

--- a/main.secrets.tf
+++ b/main.secrets.tf
@@ -18,6 +18,7 @@ resource "azurerm_role_assignment" "secrets" {
   for_each = local.secrets_role_assignments
 
   principal_id                           = each.value.role_assignment.principal_id
+  principal_type                         = each.value.role_assignment.principal_type
   scope                                  = azurerm_key_vault_secret.this[each.value.secret_key].resource_versionless_id
   condition                              = each.value.role_assignment.condition
   condition_version                      = each.value.role_assignment.condition_version

--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,7 @@ resource "azurerm_role_assignment" "this" {
   for_each = var.role_assignments
 
   principal_id                           = each.value.principal_id
+  principal_type                         = each.value.principal_type
   scope                                  = azurerm_key_vault.this.id
   condition                              = each.value.condition
   condition_version                      = each.value.condition_version

--- a/variables.tf
+++ b/variables.tf
@@ -127,6 +127,7 @@ variable "keys" {
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string
+      principal_type                         = optional(string, "ServicePrincipal")
       description                            = optional(string, null)
       skip_service_principal_aad_check       = optional(bool, false)
       condition                              = optional(string, null)
@@ -216,6 +217,7 @@ variable "private_endpoints" {
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string
+      principal_type                         = optional(string, "ServicePrincipal")
       description                            = optional(string, null)
       skip_service_principal_aad_check       = optional(bool, false)
       condition                              = optional(string, null)
@@ -278,6 +280,7 @@ variable "role_assignments" {
   type = map(object({
     role_definition_id_or_name             = string
     principal_id                           = string
+    principal_type                         = optional(string, "ServicePrincipal")
     description                            = optional(string, null)
     skip_service_principal_aad_check       = optional(bool, false)
     condition                              = optional(string, null)
@@ -290,6 +293,7 @@ A map of role assignments to create on the Key Vault. The map key is deliberatel
 
 - `role_definition_id_or_name` - The ID or name of the role definition to assign to the principal.
 - `principal_id` - The ID of the principal to assign the role to.
+- `principal_type` - The type of the principal_id. Possible values are User, Group and ServicePrincipal. Changing this forces a new resource to be created.
 - `description` - The description of the role assignment.
 - `skip_service_principal_aad_check` - If set to true, skips the Azure Active Directory check for the service principal in the tenant. Defaults to false.
 - `condition` - The condition which will be used to scope the role assignment.
@@ -310,6 +314,7 @@ variable "secrets" {
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string
+      principal_type                         = optional(string, "ServicePrincipal")
       description                            = optional(string, null)
       skip_service_principal_aad_check       = optional(bool, false)
       condition                              = optional(string, null)


### PR DESCRIPTION
Hello everyone,

in our case, we need to grant permissions for the Azure Key Vault to a group. 
In order to do this, we need to set the type of the pricipal in the Terraform code. 
However, the corresponding attribute is missing.
In my pull request, I implemented the attribute `principal_type` and tested it in our environment.

It would be nice if these modifications could be integrated into the module.

Many thanks and best regards
andy
