### PR TITLE
Secret object validation rules

### DIFF
--- a/locals.version.tf.json
+++ b/locals.version.tf.json
@@ -1,5 +1,5 @@
 {
   "locals": {
-    "module_version": "0.5.3"
+    "module_version": "0.5.4"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -340,6 +340,16 @@ DESCRIPTION
     ])
     error_message = "Secret names may only contain alphanumerics and hyphens, and be between 1 and 127 characters in length."
   }
+
+  validation {
+    condition = alltrue([
+      for key, secret in var.secrets : (
+        (secret.not_before_date == null || can(regex("^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\\.[0-9]+)?(([Zz])|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))$", secret.not_before_date))) &&
+        (secret.expiration_date == null || can(regex("^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\\.[0-9]+)?(([Zz])|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))$", secret.expiration_date)))
+      )
+    ])
+    error_message = "Secret `not_before_date` or `expiration_date` must be a valid RFC 3339 date format (YYYY-MM-DDThh:mm:ssZ)."
+  }
 }
 
 variable "secrets_value" {

--- a/variables.tf
+++ b/variables.tf
@@ -333,6 +333,13 @@ Supply role assignments in the same way as for `var.role_assignments`.
 > Note: the `value` of the secret is supplied via the `var.secrets_value` variable. Make sure to use the same map key.
 DESCRIPTION
   nullable    = false
+
+  validation {
+    condition = alltrue([
+      for key, secret in var.secrets : can(regex("^[A-Za-z0-9-]{1,127}$", secret.name))
+    ])
+    error_message = "Secret names may only contain alphanumerics and hyphens, and be between 1 and 127 characters in length."
+  }
 }
 
 variable "secrets_value" {

--- a/variables.tf
+++ b/variables.tf
@@ -340,7 +340,6 @@ DESCRIPTION
     ])
     error_message = "Secret names may only contain alphanumerics and hyphens, and be between 1 and 127 characters in length."
   }
-
   validation {
     condition = alltrue([
       for key, secret in var.secrets : (


### PR DESCRIPTION
## Description

This PR closes #71 by adding validation rules for secret names, not-before dates, and expiration dates.

Invalid name validation:
![image](https://github.com/Azure/terraform-azurerm-avm-res-keyvault-vault/assets/91114720/d55bff56-729a-4d9d-a0b0-87416e623ca5)

Invalid RFC 3339 date:
![image](https://github.com/Azure/terraform-azurerm-avm-res-keyvault-vault/assets/91114720/df0f8ad7-c783-42c4-8992-08ad906f6c15)

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks