### PR TITLE
Fix Private endpoint with static IP - change the private_endpoint member name to "default"

### DIFF
--- a/main.private_endpoint.tf
+++ b/main.private_endpoint.tf
@@ -20,7 +20,7 @@ resource "azurerm_private_endpoint" "this" {
     content {
       name               = ip_configuration.value.name
       private_ip_address = ip_configuration.value.private_ip_address
-      member_name        = "vault"
+      member_name        = "default"
       subresource_name   = "vault"
     }
   }


### PR DESCRIPTION
## Description
This pull request includes a change to the `main.private_endpoint.tf` file. The change modifies the `member_name` from `"vault"` to `"default"` in the `resource "azurerm_private_endpoint" "this"` block. This is to address the bug#108.
<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #108 
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
