### PR TITLE
feat: add key and secret ID values to output

### DIFF
--- a/examples/create-key/README.md
+++ b/examples/create-key/README.md
@@ -15,13 +15,13 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.71"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.5"
-    }
     http = {
       source  = "hashicorp/http"
       version = "~> 3.4"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
     }
   }
 }

--- a/examples/create-key/main.tf
+++ b/examples/create-key/main.tf
@@ -9,13 +9,13 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.71"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.5"
-    }
     http = {
       source  = "hashicorp/http"
       version = "~> 3.4"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
     }
   }
 }

--- a/examples/create-secret/README.md
+++ b/examples/create-secret/README.md
@@ -15,13 +15,13 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.71"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.5"
-    }
     http = {
       source  = "hashicorp/http"
       version = "~> 3.4"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
     }
   }
 }

--- a/examples/create-secret/main.tf
+++ b/examples/create-secret/main.tf
@@ -9,13 +9,13 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.71"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.5"
-    }
     http = {
       source  = "hashicorp/http"
       version = "~> 3.4"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
     }
   }
 }

--- a/locals.version.tf.json
+++ b/locals.version.tf.json
@@ -1,5 +1,5 @@
 {
   "locals": {
-    "module_version": "0.5.3"
+    "module_version": "0.6.1"
   }
 }

--- a/modules/key/README.md
+++ b/modules/key/README.md
@@ -199,6 +199,10 @@ Default: `null`
 
 The following outputs are exported:
 
+### <a name="output_id"></a> [id](#output\_id)
+
+Description: The Key Vault Key ID
+
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: The Azure resource id of the secret.
@@ -206,6 +210,10 @@ Description: The Azure resource id of the secret.
 ### <a name="output_resource_versionless_id"></a> [resource\_versionless\_id](#output\_resource\_versionless\_id)
 
 Description: The versionless Azure resource id of the secret.
+
+### <a name="output_versionless_id"></a> [versionless\_id](#output\_versionless\_id)
+
+Description: The Base ID of the Key Vault Key
 
 ## Modules
 

--- a/modules/key/outputs.tf
+++ b/modules/key/outputs.tf
@@ -1,3 +1,8 @@
+output "id" {
+  description = "The Key Vault Key ID"
+  value       = azurerm_key_vault_key.this.id
+}
+
 output "resource_id" {
   description = "The Azure resource id of the secret."
   value       = azurerm_key_vault_key.this.resource_id
@@ -6,4 +11,9 @@ output "resource_id" {
 output "resource_versionless_id" {
   description = "The versionless Azure resource id of the secret."
   value       = azurerm_key_vault_key.this.resource_versionless_id
+}
+
+output "versionless_id" {
+  description = "The Base ID of the Key Vault Key"
+  value       = azurerm_key_vault_key.this.versionless_id
 }

--- a/modules/secret/README.md
+++ b/modules/secret/README.md
@@ -144,6 +144,10 @@ Default: `null`
 
 The following outputs are exported:
 
+### <a name="output_id"></a> [id](#output\_id)
+
+Description: The Key Vault Secret ID
+
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: The Azure resource id of the secret.
@@ -151,6 +155,10 @@ Description: The Azure resource id of the secret.
 ### <a name="output_resource_versionless_id"></a> [resource\_versionless\_id](#output\_resource\_versionless\_id)
 
 Description: The versionless Azure resource id of the secret.
+
+### <a name="output_versionless_id"></a> [versionless\_id](#output\_versionless\_id)
+
+Description: The Base ID of the Key Vault Secret
 
 ## Modules
 

--- a/modules/secret/outputs.tf
+++ b/modules/secret/outputs.tf
@@ -1,3 +1,8 @@
+output "id" {
+  description = "The Key Vault Secret ID"
+  value       = azurerm_key_vault_secret.this.id
+}
+
 output "resource_id" {
   description = "The Azure resource id of the secret."
   value       = azurerm_key_vault_secret.this.resource_id
@@ -6,4 +11,9 @@ output "resource_id" {
 output "resource_versionless_id" {
   description = "The versionless Azure resource id of the secret."
   value       = azurerm_key_vault_secret.this.resource_versionless_id
+}
+
+output "versionless_id" {
+  description = "The Base ID of the Key Vault Secret"
+  value       = azurerm_key_vault_secret.this.versionless_id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,8 @@ output "keys_resource_ids" {
   value = { for kk, kv in module.keys : kk => {
     resource_id             = kv.resource_id
     resource_versionless_id = kv.resource_versionless_id
-
+    id                      = kv.id
+    versionless_id          = kv.versionless_id
     }
   }
 }
@@ -23,6 +24,8 @@ output "secrets_resource_ids" {
   value = { for sk, sv in module.secrets : sk => {
     resource_id             = sv.resource_id
     resource_versionless_id = sv.resource_versionless_id
+    id                      = sv.id
+    versionless_id          = sv.versionless_id
     }
   }
 }


### PR DESCRIPTION
## Description

Added the key and secret id and versionless_id values to the output.  This is required for some AzureRM resources that use these ID's instead of the full resource_id as inputs.

Fixes #120  and closes #120 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ x] Azure Verified Module updates:
  - [x ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
    - [ x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
  - [x ] Update to documentation

# Checklist

- [ x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
