### PR TITLE
adding back vault_uri output

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ Description: The Azure resource id of the key vault.
 
 Description: A map of secret keys to resource ids.
 
-### <a name="output_vault_uri"></a> [vault\_uri](#output\_vault\_uri)
+### <a name="output_uri"></a> [uri](#output\_uri)
 
 Description: The URI of the vault for performing operations on keys and secrets
 

--- a/README.md
+++ b/README.md
@@ -519,6 +519,10 @@ Description: The Azure resource id of the key vault.
 
 Description: A map of secret keys to resource ids.
 
+### <a name="output_vault_uri"></a> [vault\_uri](#output\_vault\_uri)
+
+Description: The URI of the vault for performing operations on keys and secrets
+
 ## Modules
 
 The following Modules are called:

--- a/locals.version.tf.json
+++ b/locals.version.tf.json
@@ -1,5 +1,5 @@
 {
   "locals": {
-    "module_version": "0.6.1"
+    "module_version": "0.6.2"
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,3 +29,8 @@ output "secrets_resource_ids" {
     }
   }
 }
+
+output "vault_uri" {
+  description = "The URI of the vault for performing operations on keys and secrets"
+  value       = azurerm_key_vault.this.vault_uri
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,7 +30,7 @@ output "secrets_resource_ids" {
   }
 }
 
-output "vault_uri" {
+output "uri" {
   description = "The URI of the vault for performing operations on keys and secrets"
   value       = azurerm_key_vault.this.vault_uri
 }


### PR DESCRIPTION
## Description

Adding back the vault_uri for use in virtual machine extensions without requiring an additional data resource.

Fixes #122 
Closes #122 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ x] Azure Verified Module updates:
  - [ x] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
    - [x ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
  - [ x] Update to documentation

# Checklist

- [x ] I'm sure there are no other open Pull Requests for the same update/change
- [x ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
