### PR TITLE
Add dependency on private endpoint for Key Vault keys and secrets

### DIFF
--- a/locals.version.tf.json
+++ b/locals.version.tf.json
@@ -1,1 +1,0 @@
-{"locals":{"module_version":"0.1.0"}}

--- a/main.keys.tf
+++ b/main.keys.tf
@@ -15,7 +15,8 @@ module "keys" {
   role_assignments      = each.value.role_assignments
 
   depends_on = [
-    time_sleep.wait_for_rbac_before_key_operations,
+    azurerm_private_endpoint.this,
+    time_sleep.wait_for_rbac_before_key_operations
   ]
 }
 

--- a/main.secrets.tf
+++ b/main.secrets.tf
@@ -12,6 +12,7 @@ module "secrets" {
   role_assignments      = each.value.role_assignments
 
   depends_on = [
+    azurerm_private_endpoint.this,
     time_sleep.wait_for_rbac_before_secret_operations
   ]
 }


### PR DESCRIPTION
## Description
When using a Key Vault with a private endpoint the keys and secrets are dependent on the private endpoint for communication.
Without this depends_on the private endpoint is destroyed before the keys and secrets are destroyed and Terraform errors out.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
