### PR TITLE
add lifecycle ignore to private endpoint if dns is unmanaged

### DIFF
--- a/main.private_endpoint.tf
+++ b/main.private_endpoint.tf
@@ -62,6 +62,10 @@ resource "azurerm_private_endpoint" "this_unmanaged_dns_zone_groups" {
       subresource_name   = "vault"
     }
   }
+
+  lifecycle {
+    ignore_changes = [private_dns_zone_group]
+  }
 }
 
 resource "azurerm_private_endpoint_application_security_group_association" "this" {


### PR DESCRIPTION
## Description
Bring the Key Vault module in line with Service Bus and ignore DNS zone changes if the lifecycle is managed by something other than Terraform, for example; by policy.

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ x ] Azure Verified Module updates:
  - [ x ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
  - [ ] Update to documentation

# Checklist

- [ x ] I'm sure there are no other open Pull Requests for the same update/change
- [ x ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ x ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
