### PR TITLE
Workaround for handling private endpoints on KeyVault creation

### DIFF
--- a/modules/key/main.tf
+++ b/modules/key/main.tf
@@ -1,32 +1,37 @@
-resource "azurerm_key_vault_key" "this" {
-  key_opts        = var.opts
-  key_type        = var.type
-  key_vault_id    = var.key_vault_resource_id
-  name            = var.name
-  curve           = var.curve
-  expiration_date = var.expiration_date
-  key_size        = var.size
-  not_before_date = var.not_before_date
-  tags            = var.tags
-
-  dynamic "rotation_policy" {
-    for_each = var.rotation_policy != null ? [var.rotation_policy] : []
-    content {
-      expire_after         = rotation_policy.value.expire_after
-      notify_before_expiry = rotation_policy.value.notify_before_expiry
-
-      automatic {
-        time_before_expiry = rotation_policy.value.automatic.time_before_expiry
+resource "azapi_resource" "key" {
+  name = var.name
+  tags = var.tags
+  type = "Microsoft.KeyVault/vaults/keys@2023-02-01" 
+  body = jsonencode ({
+    properties =   {
+      attributes  = {
+        enabled = true
+        exp = var.expiration_date
+        nbf = var.not_before_date
       }
-    }
-  }
+      curveName = var.curve
+      keyOps = var.opts
+      keySize = var.size
+      kty = var.type
+      rotationPolicy = var.rotation_policy != null ? jsonencode({
+        expire_after = var.rotation_policy.expire_after,
+        notify_before_expiry = var.rotation_policy.notify_before_expiry,
+  
+        automatic = {
+          time_before_expiry = var.rotation_policy.automatic.time_before_expiry  
+        }
+      }) : null,
+    }  
+  })
+  parent_id = "${var.key_vault_resource_id}"
+  response_export_values = ["*"]
 }
 
 resource "azurerm_role_assignment" "this" {
   for_each = var.role_assignments
 
   principal_id                           = each.value.principal_id
-  scope                                  = azurerm_key_vault_key.this.resource_versionless_id
+  scope                                  = azapi_resource.key.id
   condition                              = each.value.condition
   condition_version                      = each.value.condition_version
   delegated_managed_identity_resource_id = each.value.delegated_managed_identity_resource_id

--- a/modules/key/outputs.tf
+++ b/modules/key/outputs.tf
@@ -1,19 +1,24 @@
 output "id" {
   description = "The Key Vault Key ID"
-  value       = azurerm_key_vault_key.this.id
+  value       = azapi_resource.key.id
 }
 
 output "resource_id" {
   description = "The Azure resource id of the secret."
-  value       = azurerm_key_vault_key.this.resource_id
+    value = "${azapi_resource.key.output.id}/${
+    replace(
+      jsondecode(azapi_resource.key.output).properties.keyUriWithVersion, 
+      "/(.+)$","$1"
+    )
+  }" 
 }
 
 output "resource_versionless_id" {
   description = "The versionless Azure resource id of the secret."
-  value       = azurerm_key_vault_key.this.resource_versionless_id
+  value       = azapi_resource.key.output.id
 }
 
 output "versionless_id" {
   description = "The Base ID of the Key Vault Key"
-  value       = azurerm_key_vault_key.this.versionless_id
+  value       = azapi_resource.key.output.properties.keyUri
 }

--- a/modules/key/terraform.tf
+++ b/modules/key/terraform.tf
@@ -1,6 +1,10 @@
 terraform {
   required_version = "~> 1.9"
   required_providers {
+    azapi = {
+      source = "Azure/azapi"
+      version = ">= 1.9.0, < 2.0.0"
+    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 3.71"

--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -1,18 +1,27 @@
-resource "azurerm_key_vault_secret" "this" {
-  key_vault_id    = var.key_vault_resource_id
-  name            = var.name
-  value           = var.value
-  content_type    = var.content_type
-  expiration_date = var.expiration_date
-  not_before_date = var.not_before_date
-  tags            = var.tags
+resource "azapi_resource" "secret" {
+  name = var.name
+  tags = var.tags
+  type = "Microsoft.KeyVault/vaults/secrets@2023-02-01" 
+  body = jsonencode ({
+    properties =   {
+      contentType = var.content_type
+      value = var.value
+      attributes  = ({
+        enabled = true
+        exp = var.expiration_date
+        nbf = var.not_before_date
+      })
+    }  
+  })
+  parent_id = "${var.key_vault_resource_id}"
+  response_export_values = ["*"]
 }
 
 resource "azurerm_role_assignment" "this" {
   for_each = var.role_assignments
 
   principal_id                           = each.value.principal_id
-  scope                                  = azurerm_key_vault_secret.this.resource_versionless_id
+  scope                                  = azapi_resource.secret.id
   condition                              = each.value.condition
   condition_version                      = each.value.condition_version
   delegated_managed_identity_resource_id = each.value.delegated_managed_identity_resource_id

--- a/modules/secret/outputs.tf
+++ b/modules/secret/outputs.tf
@@ -1,19 +1,24 @@
 output "id" {
   description = "The Key Vault Secret ID"
-  value       = azurerm_key_vault_secret.this.id
+  value       = azapi_resource.secret.id
 }
 
 output "resource_id" {
   description = "The Azure resource id of the secret."
-  value       = azurerm_key_vault_secret.this.resource_id
+  value = "${azapi_resource.secret.output.id}/${
+    replace(
+      jsondecode(azapi_resource.secret.output).properties.secretUriWithVersion, 
+      "/(.+)$","$1"
+    )
+  }" 
 }
 
 output "resource_versionless_id" {
-  description = "The versionless Azure resource id of the secret."
-  value       = azurerm_key_vault_secret.this.resource_versionless_id
+ description = "The versionless Azure resource id of the secret."
+ value       = azapi_resource.secret.output.id
 }
 
 output "versionless_id" {
   description = "The Base ID of the Key Vault Secret"
-  value       = azurerm_key_vault_secret.this.versionless_id
+  value       = azapi_resource.secret.output.properties.secretUri
 }

--- a/modules/secret/terraform.tf
+++ b/modules/secret/terraform.tf
@@ -1,6 +1,10 @@
 terraform {
   required_version = "~> 1.9"
   required_providers {
+    azapi = {
+      source = "Azure/azapi"
+      version = ">= 1.9.0, < 2.0.0"
+    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 3.71"

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,6 +1,10 @@
 terraform {
   required_version = "~> 1.9"
   required_providers {
+    azapi = {
+      source = "Azure/azapi"
+      version = ">= 1.9.0, < 2.0.0"
+    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 3.71"


### PR DESCRIPTION
## Description

When trying to create a keyvault with a key in the same terraform run the run fails as the private endpoint needs to create first before a key is created. Leveraging azapi ensures the key is created in the same run.

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [x] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
