### PR TITLE
Closes #155 : upgrading azurerm provider to v3.87

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.71)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.87)
 
 - <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
 

--- a/examples/access-policies/README.md
+++ b/examples/access-policies/README.md
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.71"
+      version = ">= 3.87"
     }
     random = {
       source  = "hashicorp/random"
@@ -75,7 +75,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.71)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.87)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
 

--- a/examples/access-policies/main.tf
+++ b/examples/access-policies/main.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.71"
+      version = ">= 3.87"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/create-key/README.md
+++ b/examples/create-key/README.md
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.71"
+      version = ">= 3.87"
     }
     http = {
       source  = "hashicorp/http"
@@ -107,7 +107,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.71)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.87)
 
 - <a name="requirement_http"></a> [http](#requirement\_http) (~> 3.4)
 

--- a/examples/create-key/main.tf
+++ b/examples/create-key/main.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.71"
+      version = ">= 3.87"
     }
     http = {
       source  = "hashicorp/http"

--- a/examples/create-secret/README.md
+++ b/examples/create-secret/README.md
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.71"
+      version = ">= 3.87"
     }
     http = {
       source  = "hashicorp/http"
@@ -100,7 +100,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.71)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.87)
 
 - <a name="requirement_http"></a> [http](#requirement\_http) (~> 3.4)
 

--- a/examples/create-secret/main.tf
+++ b/examples/create-secret/main.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.71"
+      version = ">= 3.87"
     }
     http = {
       source  = "hashicorp/http"

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.71"
+      version = ">= 3.87"
     }
     random = {
       source  = "hashicorp/random"
@@ -76,7 +76,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.71)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.87)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.71"
+      version = ">= 3.87"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/diagnostic-settings/README.md
+++ b/examples/diagnostic-settings/README.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.71"
+      version = ">= 3.87"
     }
     random = {
       source  = "hashicorp/random"
@@ -80,7 +80,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.71)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.87)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
 

--- a/examples/diagnostic-settings/main.tf
+++ b/examples/diagnostic-settings/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.71"
+      version = ">= 3.87"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/private-endpoint/README.md
+++ b/examples/private-endpoint/README.md
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.71"
+      version = ">= 3.87"
     }
     random = {
       source  = "hashicorp/random"
@@ -110,7 +110,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.71)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.87)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
 

--- a/examples/private-endpoint/main.tf
+++ b/examples/private-endpoint/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.71"
+      version = ">= 3.87"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/key/README.md
+++ b/modules/key/README.md
@@ -51,13 +51,13 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.71)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.87)
 
 ## Providers
 
 The following providers are used by this module:
 
-- <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (>= 3.71)
+- <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (>= 3.87)
 
 ## Resources
 

--- a/modules/key/terraform.tf
+++ b/modules/key/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.71"
+      version = ">= 3.87"
     }
   }
 }

--- a/modules/secret/README.md
+++ b/modules/secret/README.md
@@ -36,13 +36,13 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.9)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.71)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.87)
 
 ## Providers
 
 The following providers are used by this module:
 
-- <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (>= 3.71)
+- <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (>= 3.87)
 
 ## Resources
 

--- a/modules/secret/terraform.tf
+++ b/modules/secret/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.71"
+      version = ">= 3.87"
     }
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.71"
+      version = ">= 3.87"
     }
     modtm = {
       source  = "azure/modtm"


### PR DESCRIPTION
## Description

As mentioned in #155 by @nickmladenov : 

> Looking through the [official provider release notes](https://github.com/hashicorp/terraform-provider-azurerm/releases/tag/v3.87.0) the azurerm_role_assignment resource only got introduced support for the principal_type property in release v3.87.0.

I'm upgrading the provider version to 3.87

Fixes #155 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
