### PR TITLE
fix(key): Set missing attribute "time_after_creation" for rotation po…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ avm.tflint_example.merged.hcl
 .DS_Store
 avm.tflint_module.hcl
 avm.tflint_module.merged.hcl
+
+examples/*/policy
+*.mptfbackup

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Requires `var.legacy_access_policies_enabled` to be `true`.
 - `certifiate_permissions` - (Optional) A list of certificate permissions. Possible values are: `Backup`, `Create`, `Delete`, `DeleteIssuers`, `Get`, `GetIssuers`, `Import`, `List`, `ListIssuers`, `ManageContacts`, `ManageIssuers`, `Purge`, `Recover`, `Restore`, `SetIssuers`, and `Update`.
 - `key_permissions` - (Optional) A list of key permissions. Possible value are: `Backup`, `Create`, `Decrypt`, `Delete`, `Encrypt`, `Get`, `Import`, `List`, `Purge`, `Recover`, `Restore`, `Sign`, `UnwrapKey`, `Update`, `Verify`, `WrapKey`, `Release`, `Rotate`, `GetRotationPolicy`, and `SetRotationPolicy`.
 - `secret_permissions` - (Optional) A list of secret permissions. Possible values are: `Backup`, `Delete`, `Get`, `List`, `Purge`, `Recover`, `Restore`, and `Set`.
-- `storage_permissions` - (Optional) A list of storage permissions. Possible values are: `Backup`, `Delete`, `DeleteSAS`, `Get`, `GetSAS`, `List`, `ListSas`, `Purge`, `Recover`, `RegenerateKey`, `Restore`, `Set`, `SetSAS`, and `Update`.
+- `storage_permissions` - (Optional) A list of storage permissions. Possible values are: `Backup`, `Delete`, `DeleteSAS`, `Get`, `GetSAS`, `List`, `ListSAS`, `Purge`, `Recover`, `RegenerateKey`, `Restore`, `Set`, `SetSAS`, and `Update`.
 
 Type:
 

--- a/examples/access-policies/README.md
+++ b/examples/access-policies/README.md
@@ -52,19 +52,20 @@ resource "azurerm_resource_group" "this" {
 # This is the module call
 module "keyvault" {
   source = "../../"
+
+  location = azurerm_resource_group.this.location
   # source              = "Azure/avm-res-keyvault-vault/azurerm"
-  name                           = module.naming.key_vault.name_unique
-  enable_telemetry               = var.enable_telemetry
-  location                       = azurerm_resource_group.this.location
-  resource_group_name            = azurerm_resource_group.this.name
-  tenant_id                      = data.azurerm_client_config.this.tenant_id
-  legacy_access_policies_enabled = true
+  name                = module.naming.key_vault.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  tenant_id           = data.azurerm_client_config.this.tenant_id
+  enable_telemetry    = var.enable_telemetry
   legacy_access_policies = {
     test = {
       object_id               = data.azurerm_client_config.this.object_id
       certificate_permissions = ["Get", "List"]
     }
   }
+  legacy_access_policies_enabled = true
 }
 ```
 

--- a/examples/access-policies/main.tf
+++ b/examples/access-policies/main.tf
@@ -46,17 +46,18 @@ resource "azurerm_resource_group" "this" {
 # This is the module call
 module "keyvault" {
   source = "../../"
+
+  location = azurerm_resource_group.this.location
   # source              = "Azure/avm-res-keyvault-vault/azurerm"
-  name                           = module.naming.key_vault.name_unique
-  enable_telemetry               = var.enable_telemetry
-  location                       = azurerm_resource_group.this.location
-  resource_group_name            = azurerm_resource_group.this.name
-  tenant_id                      = data.azurerm_client_config.this.tenant_id
-  legacy_access_policies_enabled = true
+  name                = module.naming.key_vault.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  tenant_id           = data.azurerm_client_config.this.tenant_id
+  enable_telemetry    = var.enable_telemetry
   legacy_access_policies = {
     test = {
       object_id               = data.azurerm_client_config.this.object_id
       certificate_permissions = ["Get", "List"]
     }
   }
+  legacy_access_policies_enabled = true
 }

--- a/examples/create-key/README.md
+++ b/examples/create-key/README.md
@@ -62,13 +62,13 @@ data "azurerm_client_config" "current" {}
 
 module "key_vault" {
   source = "../../"
+
+  location = azurerm_resource_group.this.location
   # source             = "Azure/avm-res-keyvault-vault/azurerm"
-  name                          = module.naming.key_vault.name_unique
-  location                      = azurerm_resource_group.this.location
-  enable_telemetry              = var.enable_telemetry
-  resource_group_name           = azurerm_resource_group.this.name
-  tenant_id                     = data.azurerm_client_config.current.tenant_id
-  public_network_access_enabled = true
+  name                = module.naming.key_vault.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  enable_telemetry    = var.enable_telemetry
   keys = {
     cmk_for_storage_account = {
       key_opts = [
@@ -84,6 +84,11 @@ module "key_vault" {
       key_size = 2048
     }
   }
+  network_acls = {
+    bypass   = "AzureServices"
+    ip_rules = ["${data.http.ip.response_body}/32"]
+  }
+  public_network_access_enabled = true
   role_assignments = {
     deployment_user_kv_admin = {
       role_definition_id_or_name = "Key Vault Administrator"
@@ -92,10 +97,6 @@ module "key_vault" {
   }
   wait_for_rbac_before_key_operations = {
     create = "60s"
-  }
-  network_acls = {
-    bypass   = "AzureServices"
-    ip_rules = ["${data.http.ip.response_body}/32"]
   }
 }
 ```

--- a/examples/create-key/main.tf
+++ b/examples/create-key/main.tf
@@ -56,13 +56,13 @@ data "azurerm_client_config" "current" {}
 
 module "key_vault" {
   source = "../../"
+
+  location = azurerm_resource_group.this.location
   # source             = "Azure/avm-res-keyvault-vault/azurerm"
-  name                          = module.naming.key_vault.name_unique
-  location                      = azurerm_resource_group.this.location
-  enable_telemetry              = var.enable_telemetry
-  resource_group_name           = azurerm_resource_group.this.name
-  tenant_id                     = data.azurerm_client_config.current.tenant_id
-  public_network_access_enabled = true
+  name                = module.naming.key_vault.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  enable_telemetry    = var.enable_telemetry
   keys = {
     cmk_for_storage_account = {
       key_opts = [
@@ -78,6 +78,11 @@ module "key_vault" {
       key_size = 2048
     }
   }
+  network_acls = {
+    bypass   = "AzureServices"
+    ip_rules = ["${data.http.ip.response_body}/32"]
+  }
+  public_network_access_enabled = true
   role_assignments = {
     deployment_user_kv_admin = {
       role_definition_id_or_name = "Key Vault Administrator"
@@ -86,9 +91,5 @@ module "key_vault" {
   }
   wait_for_rbac_before_key_operations = {
     create = "60s"
-  }
-  network_acls = {
-    bypass   = "AzureServices"
-    ip_rules = ["${data.http.ip.response_body}/32"]
   }
 }

--- a/examples/create-secret/README.md
+++ b/examples/create-secret/README.md
@@ -62,13 +62,24 @@ data "azurerm_client_config" "current" {}
 
 module "key_vault" {
   source = "../../"
+
+  location = azurerm_resource_group.this.location
   # source             = "Azure/avm-res-keyvault-vault/azurerm"
-  name                          = module.naming.key_vault.name_unique
-  location                      = azurerm_resource_group.this.location
-  enable_telemetry              = var.enable_telemetry
-  resource_group_name           = azurerm_resource_group.this.name
-  tenant_id                     = data.azurerm_client_config.current.tenant_id
+  name                = module.naming.key_vault.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  enable_telemetry    = var.enable_telemetry
+  network_acls = {
+    bypass   = "AzureServices"
+    ip_rules = ["${data.http.ip.response_body}/32"]
+  }
   public_network_access_enabled = true
+  role_assignments = {
+    deployment_user_kv_admin = {
+      role_definition_id_or_name = "Key Vault Administrator"
+      principal_id               = data.azurerm_client_config.current.object_id
+    }
+  }
   secrets = {
     test_secret = {
       name = "test-secret"
@@ -77,24 +88,11 @@ module "key_vault" {
   secrets_value = {
     test_secret = "secret-value"
   }
-  role_assignments = {
-    deployment_user_kv_admin = {
-      role_definition_id_or_name = "Key Vault Administrator"
-      principal_id               = data.azurerm_client_config.current.object_id
-    }
-  }
   wait_for_rbac_before_secret_operations = {
     create = "60s"
   }
-  network_acls = {
-    bypass   = "AzureServices"
-    ip_rules = ["${data.http.ip.response_body}/32"]
-  }
 }
 
-output "secrets" {
-  value = module.key_vault.secrets
-}
 ```
 
 <!-- markdownlint-disable MD033 -->

--- a/examples/create-secret/main.tf
+++ b/examples/create-secret/main.tf
@@ -56,13 +56,24 @@ data "azurerm_client_config" "current" {}
 
 module "key_vault" {
   source = "../../"
+
+  location = azurerm_resource_group.this.location
   # source             = "Azure/avm-res-keyvault-vault/azurerm"
-  name                          = module.naming.key_vault.name_unique
-  location                      = azurerm_resource_group.this.location
-  enable_telemetry              = var.enable_telemetry
-  resource_group_name           = azurerm_resource_group.this.name
-  tenant_id                     = data.azurerm_client_config.current.tenant_id
+  name                = module.naming.key_vault.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  enable_telemetry    = var.enable_telemetry
+  network_acls = {
+    bypass   = "AzureServices"
+    ip_rules = ["${data.http.ip.response_body}/32"]
+  }
   public_network_access_enabled = true
+  role_assignments = {
+    deployment_user_kv_admin = {
+      role_definition_id_or_name = "Key Vault Administrator"
+      principal_id               = data.azurerm_client_config.current.object_id
+    }
+  }
   secrets = {
     test_secret = {
       name = "test-secret"
@@ -71,21 +82,8 @@ module "key_vault" {
   secrets_value = {
     test_secret = "secret-value"
   }
-  role_assignments = {
-    deployment_user_kv_admin = {
-      role_definition_id_or_name = "Key Vault Administrator"
-      principal_id               = data.azurerm_client_config.current.object_id
-    }
-  }
   wait_for_rbac_before_secret_operations = {
     create = "60s"
   }
-  network_acls = {
-    bypass   = "AzureServices"
-    ip_rules = ["${data.http.ip.response_body}/32"]
-  }
 }
 
-output "secrets" {
-  value = module.key_vault.secrets
-}

--- a/examples/create-secret/outputs.tf
+++ b/examples/create-secret/outputs.tf
@@ -1,0 +1,3 @@
+output "secrets" {
+  value = module.key_vault.secrets
+}

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -52,12 +52,13 @@ resource "azurerm_resource_group" "this" {
 # This is the module call
 module "keyvault" {
   source = "../../"
+
+  location = azurerm_resource_group.this.location
   # source              = "Azure/avm-res-keyvault-vault/azurerm"
   name                = module.naming.key_vault.name_unique
-  enable_telemetry    = var.enable_telemetry
-  location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
   tenant_id           = data.azurerm_client_config.this.tenant_id
+  enable_telemetry    = var.enable_telemetry
 }
 ```
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -46,10 +46,11 @@ resource "azurerm_resource_group" "this" {
 # This is the module call
 module "keyvault" {
   source = "../../"
+
+  location = azurerm_resource_group.this.location
   # source              = "Azure/avm-res-keyvault-vault/azurerm"
   name                = module.naming.key_vault.name_unique
-  enable_telemetry    = var.enable_telemetry
-  location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
   tenant_id           = data.azurerm_client_config.this.tenant_id
+  enable_telemetry    = var.enable_telemetry
 }

--- a/examples/diagnostic-settings/README.md
+++ b/examples/diagnostic-settings/README.md
@@ -58,10 +58,10 @@ resource "azurerm_log_analytics_workspace" "this" {
 # This is the module call
 module "keyvault" {
   source = "../../"
+
+  location = azurerm_resource_group.this.location
   # source             = "Azure/avm-res-keyvault-vault/azurerm"
   name                = module.naming.key_vault.name_unique
-  enable_telemetry    = var.enable_telemetry
-  location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
   tenant_id           = data.azurerm_client_config.this.tenant_id
   diagnostic_settings = {
@@ -70,6 +70,7 @@ module "keyvault" {
       workspace_resource_id = azurerm_log_analytics_workspace.this.id
     }
   }
+  enable_telemetry = var.enable_telemetry
 }
 ```
 

--- a/examples/diagnostic-settings/main.tf
+++ b/examples/diagnostic-settings/main.tf
@@ -52,10 +52,10 @@ resource "azurerm_log_analytics_workspace" "this" {
 # This is the module call
 module "keyvault" {
   source = "../../"
+
+  location = azurerm_resource_group.this.location
   # source             = "Azure/avm-res-keyvault-vault/azurerm"
   name                = module.naming.key_vault.name_unique
-  enable_telemetry    = var.enable_telemetry
-  location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
   tenant_id           = data.azurerm_client_config.this.tenant_id
   diagnostic_settings = {
@@ -64,4 +64,5 @@ module "keyvault" {
       workspace_resource_id = azurerm_log_analytics_workspace.this.id
     }
   }
+  enable_telemetry = var.enable_telemetry
 }

--- a/examples/private-endpoint/README.md
+++ b/examples/private-endpoint/README.md
@@ -73,19 +73,20 @@ resource "azurerm_private_dns_zone" "this" {
 # This is the module call
 module "keyvault" {
   source = "../../"
+
+  location = azurerm_resource_group.this.location
   # source             = "Azure/avm-res-keyvault-vault/azurerm"
-  name                          = module.naming.key_vault.name_unique
-  enable_telemetry              = var.enable_telemetry
-  location                      = azurerm_resource_group.this.location
-  resource_group_name           = azurerm_resource_group.this.name
-  tenant_id                     = data.azurerm_client_config.this.tenant_id
-  public_network_access_enabled = false
+  name                = module.naming.key_vault.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  tenant_id           = data.azurerm_client_config.this.tenant_id
+  enable_telemetry    = var.enable_telemetry
   private_endpoints = {
     primary = {
       private_dns_zone_resource_ids = [azurerm_private_dns_zone.this.id]
       subnet_resource_id            = azurerm_subnet.this.id
     }
   }
+  public_network_access_enabled = false
 }
 
 # Removed as this causes the idempotent check to fail.

--- a/examples/private-endpoint/main.tf
+++ b/examples/private-endpoint/main.tf
@@ -66,19 +66,20 @@ resource "azurerm_private_dns_zone" "this" {
 # This is the module call
 module "keyvault" {
   source = "../../"
+
+  location = azurerm_resource_group.this.location
   # source             = "Azure/avm-res-keyvault-vault/azurerm"
-  name                          = module.naming.key_vault.name_unique
-  enable_telemetry              = var.enable_telemetry
-  location                      = azurerm_resource_group.this.location
-  resource_group_name           = azurerm_resource_group.this.name
-  tenant_id                     = data.azurerm_client_config.this.tenant_id
-  public_network_access_enabled = false
+  name                = module.naming.key_vault.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  tenant_id           = data.azurerm_client_config.this.tenant_id
+  enable_telemetry    = var.enable_telemetry
   private_endpoints = {
     primary = {
       private_dns_zone_resource_ids = [azurerm_private_dns_zone.this.id]
       subnet_resource_id            = azurerm_subnet.this.id
     }
   }
+  public_network_access_enabled = false
 }
 
 # Removed as this causes the idempotent check to fail.

--- a/main.keys.tf
+++ b/main.keys.tf
@@ -2,17 +2,17 @@ module "keys" {
   source   = "./modules/key"
   for_each = var.keys
 
-  opts                  = each.value.key_opts
-  type                  = each.value.key_type
   key_vault_resource_id = azurerm_key_vault.this.id
   name                  = each.value.name
+  type                  = each.value.key_type
   curve                 = each.value.curve
   expiration_date       = each.value.expiration_date
-  size                  = each.value.key_size
   not_before_date       = each.value.not_before_date
-  tags                  = each.value.tags
-  rotation_policy       = each.value.rotation_policy
+  opts                  = each.value.key_opts
   role_assignments      = each.value.role_assignments
+  rotation_policy       = each.value.rotation_policy
+  size                  = each.value.key_size
+  tags                  = each.value.tags
 
   depends_on = [
     azurerm_private_endpoint.this,

--- a/main.secrets.tf
+++ b/main.secrets.tf
@@ -8,8 +8,8 @@ module "secrets" {
   content_type          = each.value.content_type
   expiration_date       = each.value.expiration_date
   not_before_date       = each.value.not_before_date
-  tags                  = each.value.tags
   role_assignments      = each.value.role_assignments
+  tags                  = each.value.tags
 
   depends_on = [
     azurerm_private_endpoint.this,

--- a/modules/key/README.md
+++ b/modules/key/README.md
@@ -23,7 +23,8 @@ resource "azurerm_key_vault_key" "this" {
       notify_before_expiry = rotation_policy.value.notify_before_expiry
 
       automatic {
-        time_before_expiry = rotation_policy.value.automatic.time_before_expiry
+        time_after_creation = rotation_policy.value.automatic.time_after_creation
+        time_before_expiry  = rotation_policy.value.automatic.time_before_expiry
       }
     }
   }

--- a/modules/key/main.tf
+++ b/modules/key/main.tf
@@ -17,7 +17,8 @@ resource "azurerm_key_vault_key" "this" {
       notify_before_expiry = rotation_policy.value.notify_before_expiry
 
       automatic {
-        time_before_expiry = rotation_policy.value.automatic.time_before_expiry
+        time_after_creation = rotation_policy.value.automatic.time_after_creation
+        time_before_expiry  = rotation_policy.value.automatic.time_before_expiry
       }
     }
   }

--- a/modules/secret/README.md
+++ b/modules/secret/README.md
@@ -7,11 +7,11 @@ Module to deploy key vault secrets in Azure.
 resource "azurerm_key_vault_secret" "this" {
   key_vault_id    = var.key_vault_resource_id
   name            = var.name
-  value           = var.value
   content_type    = var.content_type
   expiration_date = var.expiration_date
   not_before_date = var.not_before_date
   tags            = var.tags
+  value           = var.value
 }
 
 resource "azurerm_role_assignment" "this" {

--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -1,11 +1,11 @@
 resource "azurerm_key_vault_secret" "this" {
   key_vault_id    = var.key_vault_resource_id
   name            = var.name
-  value           = var.value
   content_type    = var.content_type
   expiration_date = var.expiration_date
   not_before_date = var.not_before_date
   tags            = var.tags
+  value           = var.value
 }
 
 resource "azurerm_role_assignment" "this" {


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

-->
This PR sets the missing attribute "time_after_creation" in the Key Rotation Policy.
This attribute is already accepted as optional in the variable.

Update to docs are not needed.

Fixes #219 
Closes #219 
Fixes #218
Closes #218 


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
