### PR TITLE
add azurerm_key_vault.this and azurerm_key_vault_access_policy.this as sensitive outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,10 @@ Default: `{}`
 
 The following outputs are exported:
 
+### <a name="output_access_policies_resource"></a> [access\_policies\_resource](#output\_access\_policies\_resource)
+
+Description: The full resource output for the Keyvault access policies map resource.
+
 ### <a name="output_keys"></a> [keys](#output\_keys)
 
 Description: A map of key keys to key values. The key value is the entire azurerm\_key\_vault\_key resource.
@@ -556,6 +560,10 @@ Description: The name of the key vault.
 
 Description: A map of private endpoints. The map key is the supplied input to var.private\_endpoints. The map value is the entire azurerm\_private\_endpoint resource.
 
+### <a name="output_resource"></a> [resource](#output\_resource)
+
+Description: The full resource output for the Keyvault resource.
+
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: The Azure resource id of the key vault.
@@ -577,14 +585,6 @@ Description: A map of secret keys to resource ids.
 ### <a name="output_uri"></a> [uri](#output\_uri)
 
 Description: The URI of the vault for performing operations on keys and secrets
-
-### <a name="output_resource"></a> [resource](#output\_resource)
-
-Description: This is the full resource output for the for the Keyvault resource.
-
-### <a name="output_access_policies_resource"></a> [access_policies_resource](#output\_access_policies_resource)
-
-Description:  Map of the full resource definition for the Key Vault access policies.
 
 ## Modules
 

--- a/examples/access-policies/README.md
+++ b/examples/access-policies/README.md
@@ -109,7 +109,15 @@ Default: `true`
 
 ## Outputs
 
-No outputs.
+The following outputs are exported:
+
+### <a name="output_access_policies_resource"></a> [access\_policies\_resource](#output\_access\_policies\_resource)
+
+Description: The full resource output for the Keyvault access policies map resource.
+
+### <a name="output_resource"></a> [resource](#output\_resource)
+
+Description: The full resource output for the Keyvault resource.
 
 ## Modules
 

--- a/examples/access-policies/outputs.tf
+++ b/examples/access-policies/outputs.tf
@@ -1,0 +1,11 @@
+output "access_policies_resource" {
+  description = "The full resource output for the Keyvault access policies map resource."
+  sensitive   = true
+  value       = module.keyvault.access_policies_resource
+}
+
+output "resource" {
+  description = "The full resource output for the Keyvault resource."
+  sensitive   = true
+  value       = module.keyvault.resource
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,9 @@
+output "access_policies_resource" {
+  description = "The full resource output for the Keyvault access policies map resource."
+  sensitive   = true
+  value       = { for pk, pv in azurerm_key_vault_access_policy.this : pk => pv }
+}
+
 output "keys" {
   description = <<DESCRIPTION
 A map of key keys to key values. The key value is the entire azurerm_key_vault_key resource.
@@ -32,6 +38,12 @@ output "private_endpoints" {
   value       = var.private_endpoints_manage_dns_zone_group ? azurerm_private_endpoint.this : azurerm_private_endpoint.this_unmanaged_dns_zone_groups
 }
 
+output "resource" {
+  description = "The full resource output for the Keyvault resource."
+  sensitive   = true
+  value       = azurerm_key_vault.this
+}
+
 output "resource_id" {
   description = "The Azure resource id of the key vault."
   value       = azurerm_key_vault.this.id
@@ -64,16 +76,4 @@ output "secrets_resource_ids" {
 output "uri" {
   description = "The URI of the vault for performing operations on keys and secrets"
   value       = azurerm_key_vault.this.vault_uri
-}
-
-output "resource" {
-  description = "The full resource output for the Keyvault resource."
-  sensitive   = true
-  value       = azurerm_key_vault.this
-}
-
-output "access_policies_resource" {
-  description = "The full resource output for the Keyvault access policies map resource."
-  sensitive   = true
-  value       = { for pk, pv in azurerm_key_vault_access_policy.this : pk => pv }
 }


### PR DESCRIPTION
## Description
### Summary

These changes add `azurerm_key_vault.this` and `azurerm_key_vault_access_policy.this` as sensitive outputs.

### Context

We are building our internal Key Vault Terraform module based on the AVM Key Vault module. As part of our quality gates, we are writing tests using the [Terraform test framework](https://developer.hashicorp.com/terraform/language/tests). To validate the configuration of the Key Vault and its access policies, we need to expose these resources through module outputs.

This approach is consistent with other AVM modules, such as the Storage Account module: [resource](https://github.com/Azure/terraform-azurerm-avm-res-storage-storageaccount/blob/f98d69b593b63616edcb54a0c3ac3f316bd5b279/outputs.tf#L36-L40), which already exposes its resource as output.

Fixes #227 

## Type of Change


- [x] Azure Verified Module updates:
  - [x] Feature update backwards compatible feature updates.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
