### PR TITLE
PR: Replace deprecated `metric` block with `enabled_metric` in azurerm_monitor_diagnostic_setting

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -75,11 +75,11 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
       category_group = enabled_log.value
     }
   }
-  dynamic "metric" {
+  dynamic "enabled_metric" {
     for_each = each.value.metric_categories
 
     content {
-      category = metric.value
+      category = enabled_metric.value
     }
   }
 }


### PR DESCRIPTION
This PR updates the `azurerm_monitor_diagnostic_setting` resource in the Key Vault module to replace the deprecated `metric` block with the new `enabled_metric` block, as required by the latest AzureRM provider. This resolves the deprecation warning and ensures compatibility with future provider versions. No other logic or resource changes are included.
This issue is a warning at present but would lead to failure in future
![image](https://github.com/user-attachments/assets/d34b4f40-79e7-4768-adf1-7a47492b7d0f)


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->