### PR TITLE
feat: add writable only secret support

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ Description: A map of secrets to create on the Key Vault. The map key is deliber
 
 Supply role assignments in the same way as for `var.role_assignments`.
 
-> Note: the `value` of the secret is supplied via the `var.secrets_value` variable. Make sure to use the same map key.
+> Note: the `value` of the secret is supplied via the `var.secrets_value` variable, or `var.secrets_value_wo` for write-only secrets. Make sure to use the same map key.
 
 Type:
 

--- a/README.md
+++ b/README.md
@@ -453,7 +453,28 @@ This is a separate variable to `var.secrets` because it is sensitive and therefo
 
 Type: `map(string)`
 
-Default: `null`
+Default: `{}`
+
+### <a name="input_secrets_value_wo"></a> [secrets\_value\_wo](#input\_secrets\_value\_wo)
+
+Description: A map of secret keys to values writable only.  
+The map key is the supplied input to `var.secrets`.  
+The map value is an object with the following attributes:
+- `value` - The value for the secret writable only.
+- `version` - The version of the secret writable only. Changing this updates the secret value.
+
+This is a separate variable to `var.secrets` because it is sensitive and therefore cannot be used in a `for_each` loop.
+
+Type:
+
+```hcl
+map(object({
+    value   = string
+    version = number
+  }))
+```
+
+Default: `{}`
 
 ### <a name="input_sku_name"></a> [sku\_name](#input\_sku\_name)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Module to deploy key vaults, keys and secrets in Azure.
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.11, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
 

--- a/README.md
+++ b/README.md
@@ -457,24 +457,27 @@ Default: `{}`
 
 ### <a name="input_secrets_value_wo"></a> [secrets\_value\_wo](#input\_secrets\_value\_wo)
 
-Description: A map of secret keys to values writable only.  
+Description: A map of secret keys to writable-only secret values.  
 The map key is the supplied input to `var.secrets`.  
-The map value is an object with the following attributes:
-- `value` - The value for the secret writable only.
-- `version` - The version of the secret writable only. Changing this updates the secret value.
+The map value is the writable-only secret value for that key.
 
-This is a separate variable to `var.secrets` because it is sensitive and therefore cannot be used in a `for_each` loop.
+Use `var.secrets_value_wo_version` with the same key to control updates when the writable-only value changes.
 
-Type:
+Type: `map(string)`
 
-```hcl
-map(object({
-    value   = string
-    version = number
-  }))
-```
+Default: `null`
 
-Default: `{}`
+### <a name="input_secrets_value_wo_version"></a> [secrets\_value\_wo\_version](#input\_secrets\_value\_wo\_version)
+
+Description: A map of secret keys to writable-only secret value versions.  
+The map key is the supplied input to `var.secrets`.  
+The map value is the version identifier for that secret value.
+
+Use the same key as `var.secrets_value_wo`; increment the version when the corresponding writable-only value changes to trigger a secret update.
+
+Type: `map(number)`
+
+Default: `null`
 
 ### <a name="input_sku_name"></a> [sku\_name](#input\_sku\_name)
 

--- a/examples/create-secret/README.md
+++ b/examples/create-secret/README.md
@@ -86,9 +86,18 @@ module "key_vault" {
     test_secret = {
       name = "test-secret"
     }
+    test_secret_wo = {
+      name = "test-secret-wo"
+    }
   }
   secrets_value = {
     test_secret = "secret-value"
+  }
+  secrets_value_wo = {
+    test_secret_wo = "secret-value-wo"
+  }
+  secrets_value_wo_version = {
+    test_secret_wo = 1
   }
   wait_for_rbac_before_secret_operations = {
     create = "60s"

--- a/examples/create-secret/README.md
+++ b/examples/create-secret/README.md
@@ -10,7 +10,7 @@ provider "azurerm" {
 }
 
 terraform {
-  required_version = ">= 1.9, < 2.0"
+  required_version = ">= 1.11, < 2.0"
 
   required_providers {
     azurerm = {
@@ -110,7 +110,7 @@ module "key_vault" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.11, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.81)
 

--- a/examples/create-secret/main.tf
+++ b/examples/create-secret/main.tf
@@ -3,7 +3,7 @@ provider "azurerm" {
 }
 
 terraform {
-  required_version = ">= 1.9, < 2.0"
+  required_version = ">= 1.11, < 2.0"
 
   required_providers {
     azurerm = {
@@ -87,10 +87,10 @@ module "key_vault" {
     test_secret = "secret-value"
   }
   secrets_value_wo = {
-    test_secret_wo = {
-      value   = "secret-value-wo"
-      version = 1
-    }
+    test_secret_wo = "secret-value-wo"
+  }
+  secrets_value_wo_version = {
+    test_secret_wo = 1
   }
   wait_for_rbac_before_secret_operations = {
     create = "60s"

--- a/examples/create-secret/main.tf
+++ b/examples/create-secret/main.tf
@@ -79,12 +79,15 @@ module "key_vault" {
     test_secret = {
       name = "test-secret"
     }
+    test_secret_wo = {
+      name = "test-secret-wo"
+    }
   }
   secrets_value = {
     test_secret = "secret-value"
   }
   secrets_value_wo = {
-    test_secret = {
+    test_secret_wo = {
       value   = "secret-value-wo"
       version = 1
     }

--- a/examples/create-secret/main.tf
+++ b/examples/create-secret/main.tf
@@ -83,6 +83,12 @@ module "key_vault" {
   secrets_value = {
     test_secret = "secret-value"
   }
+  secrets_value_wo = {
+    test_secret = {
+      value   = "secret-value-wo"
+      version = 1
+    }
+  }
   wait_for_rbac_before_secret_operations = {
     create = "60s"
   }

--- a/main.secrets.tf
+++ b/main.secrets.tf
@@ -5,8 +5,8 @@ module "secrets" {
   key_vault_resource_id = azurerm_key_vault.this.id
   name                  = each.value.name
   value                 = try(var.secrets_value[each.key], null)
-  value_wo              = try(var.secrets_value_wo[each.key].value, null)
-  value_wo_version      = try(var.secrets_value_wo[each.key].version, null)
+  value_wo              = try(var.secrets_value_wo[each.key], null)
+  value_wo_version      = try(var.secrets_value_wo_version[each.key], null)
   content_type          = each.value.content_type
   expiration_date       = each.value.expiration_date
   not_before_date       = each.value.not_before_date

--- a/main.secrets.tf
+++ b/main.secrets.tf
@@ -4,14 +4,14 @@ module "secrets" {
 
   key_vault_resource_id = azurerm_key_vault.this.id
   name                  = each.value.name
-  value                 = try(var.secrets_value[each.key], null)
-  value_wo              = try(var.secrets_value_wo[each.key], null)
-  value_wo_version      = try(var.secrets_value_wo_version[each.key], null)
   content_type          = each.value.content_type
   expiration_date       = each.value.expiration_date
   not_before_date       = each.value.not_before_date
   role_assignments      = each.value.role_assignments
   tags                  = each.value.tags
+  value                 = try(var.secrets_value[each.key], null)
+  value_wo              = try(var.secrets_value_wo[each.key], null)
+  value_wo_version      = try(var.secrets_value_wo_version[each.key], null)
 
   depends_on = [
     azurerm_private_endpoint.this,

--- a/main.secrets.tf
+++ b/main.secrets.tf
@@ -4,7 +4,9 @@ module "secrets" {
 
   key_vault_resource_id = azurerm_key_vault.this.id
   name                  = each.value.name
-  value                 = var.secrets_value[each.key]
+  value                 = try(var.secrets_value[each.key], null)
+  value_wo              = try(var.secrets_value_wo[each.key].value, null)
+  value_wo_version      = try(var.secrets_value_wo[each.key].version, null)
   content_type          = each.value.content_type
   expiration_date       = each.value.expiration_date
   not_before_date       = each.value.not_before_date

--- a/modules/secret/README.md
+++ b/modules/secret/README.md
@@ -64,12 +64,6 @@ Description: The name of the secret.
 
 Type: `string`
 
-### <a name="input_value"></a> [value](#input\_value)
-
-Description: The value for the secret.
-
-Type: `string`
-
 ## Optional Inputs
 
 The following input variables are optional (have default values):
@@ -133,6 +127,30 @@ Default: `{}`
 Description: The tags to assign to the secret.
 
 Type: `map(string)`
+
+Default: `null`
+
+### <a name="input_value"></a> [value](#input\_value)
+
+Description: The value for the secret. Must be set if `value_wo` is not set.
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_value_wo"></a> [value\_wo](#input\_value\_wo)
+
+Description: The value for the secret writable only. Must be set if `value` is not set.
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_value_wo_version"></a> [value\_wo\_version](#input\_value\_wo\_version)
+
+Description: The version of the secret writable only. Must be set if `value_wo` is not set.
+
+Type: `number`
 
 Default: `null`
 

--- a/modules/secret/README.md
+++ b/modules/secret/README.md
@@ -148,7 +148,7 @@ Default: `null`
 
 ### <a name="input_value_wo_version"></a> [value\_wo\_version](#input\_value\_wo\_version)
 
-Description: The version of the secret writable only. Must be set if `value_wo` is not set. Changing this updates the secret value.
+Description: The version of the secret writable only. Must be set if `value_wo` is set. Changing this updates the secret value.
 
 Type: `number`
 

--- a/modules/secret/README.md
+++ b/modules/secret/README.md
@@ -148,7 +148,7 @@ Default: `null`
 
 ### <a name="input_value_wo_version"></a> [value\_wo\_version](#input\_value\_wo\_version)
 
-Description: The version of the secret writable only. Must be set if `value_wo` is not set.
+Description: The version of the secret writable only. Must be set if `value_wo` is not set. Changing this updates the secret value.
 
 Type: `number`
 

--- a/modules/secret/README.md
+++ b/modules/secret/README.md
@@ -36,7 +36,7 @@ module "keyvault_secret" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.11, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.81, < 5.0)
 

--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -1,11 +1,13 @@
 resource "azurerm_key_vault_secret" "this" {
-  key_vault_id    = var.key_vault_resource_id
-  name            = var.name
-  content_type    = var.content_type
-  expiration_date = var.expiration_date
-  not_before_date = var.not_before_date
-  tags            = var.tags
-  value           = var.value
+  key_vault_id     = var.key_vault_resource_id
+  name             = var.name
+  content_type     = var.content_type
+  expiration_date  = var.expiration_date
+  not_before_date  = var.not_before_date
+  tags             = var.tags
+  value            = var.value
+  value_wo         = var.value_wo
+  value_wo_version = var.value_wo_version
 }
 
 resource "azurerm_role_assignment" "this" {

--- a/modules/secret/terraform.tf
+++ b/modules/secret/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.9, < 2.0"
+  required_version = ">= 1.11, < 2.0"
 
   required_providers {
     azurerm = {

--- a/modules/secret/variables.tf
+++ b/modules/secret/variables.tf
@@ -37,7 +37,7 @@ variable "value_wo" {
 
 variable "value_wo_version" {
   type        = number
-  description = "The version of the secret writable only. Must be set if `value_wo` is not set. Changing this updates the secret value."
+  description = "The version of the secret writable only. Must be set if `value_wo` is set. Changing this updates the secret value."
   default     = null
 }
 

--- a/modules/secret/variables.tf
+++ b/modules/secret/variables.tf
@@ -36,7 +36,7 @@ variable "value_wo" {
 
 variable "value_wo_version" {
   type        = number
-  description = "The version of the secret writable only. Must be set if `value_wo` is not set."
+  description = "The version of the secret writable only. Must be set if `value_wo` is not set. Changing this updates the secret value."
   default     = null
 }
 

--- a/modules/secret/variables.tf
+++ b/modules/secret/variables.tf
@@ -31,6 +31,7 @@ variable "value_wo" {
   type        = string
   description = "The value for the secret writable only. Must be set if `value` is not set."
   default     = null
+  ephemeral   = true
   sensitive   = true
 }
 

--- a/modules/secret/variables.tf
+++ b/modules/secret/variables.tf
@@ -22,8 +22,22 @@ variable "name" {
 
 variable "value" {
   type        = string
-  description = "The value for the secret."
+  description = "The value for the secret. Must be set if `value_wo` is not set."
+  default     = null
   sensitive   = true
+}
+
+variable "value_wo" {
+  type        = string
+  description = "The value for the secret writable only. Must be set if `value` is not set."
+  default     = null
+  sensitive   = true
+}
+
+variable "value_wo_version" {
+  type        = number
+  description = "The version of the secret writable only. Must be set if `value_wo` is not set."
+  default     = null
 }
 
 variable "content_type" {

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.9, < 2.0"
+  required_version = ">= 1.11, < 2.0"
 
   required_providers {
     azapi = {

--- a/variables.tf
+++ b/variables.tf
@@ -426,7 +426,7 @@ A map of secrets to create on the Key Vault. The map key is deliberately arbitra
 
 Supply role assignments in the same way as for `var.role_assignments`.
 
-> Note: the `value` of the secret is supplied via the `var.secrets_value` variable. Make sure to use the same map key.
+> Note: the `value` of the secret is supplied via the `var.secrets_value` variable, or `var.secrets_value_wo` for write-only secrets. Make sure to use the same map key.
 DESCRIPTION
   nullable    = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -445,21 +445,28 @@ DESCRIPTION
 }
 
 variable "secrets_value_wo" {
-  type = map(object({
-    value   = string
-    version = number
-  }))
-  default     = {}
+  type        = map(string)
+  default     = null
   description = <<DESCRIPTION
-A map of secret keys to values writable only.
+A map of secret keys to writable-only secret values.
 The map key is the supplied input to `var.secrets`.
-The map value is an object with the following attributes:
-- `value` - The value for the secret writable only.
-- `version` - The version of the secret writable only. Changing this updates the secret value.
+The map value is the writable-only secret value for that key.
 
-This is a separate variable to `var.secrets` because it is sensitive and therefore cannot be used in a `for_each` loop.
+Use `var.secrets_value_wo_version` with the same key to control updates when the writable-only value changes.
 DESCRIPTION
   sensitive   = true
+}
+
+variable "secrets_value_wo_version" {
+  type        = map(number)
+  default     = null
+  description = <<DESCRIPTION
+A map of secret keys to writable-only secret value versions.
+The map key is the supplied input to `var.secrets`.
+The map value is the version identifier for that secret value.
+
+Use the same key as `var.secrets_value_wo`; increment the version when the corresponding writable-only value changes to trigger a secret update.
+DESCRIPTION
 }
 
 variable "sku_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -454,6 +454,7 @@ The map value is the writable-only secret value for that key.
 
 Use `var.secrets_value_wo_version` with the same key to control updates when the writable-only value changes.
 DESCRIPTION
+  ephemeral   = true
   sensitive   = true
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -433,11 +433,29 @@ DESCRIPTION
 
 variable "secrets_value" {
   type        = map(string)
-  default     = null
+  default     = {}
   description = <<DESCRIPTION
 A map of secret keys to values.
 The map key is the supplied input to `var.secrets`.
 The map value is the secret value.
+
+This is a separate variable to `var.secrets` because it is sensitive and therefore cannot be used in a `for_each` loop.
+DESCRIPTION
+  sensitive   = true
+}
+
+variable "secrets_value_wo" {
+  type = map(object({
+    value   = string
+    version = number
+  }))
+  default     = {}
+  description = <<DESCRIPTION
+A map of secret keys to values writable only.
+The map key is the supplied input to `var.secrets`.
+The map value is an object with the following attributes:
+- `value` - The value for the secret writable only.
+- `version` - The version of the secret writable only. Changing this updates the secret value.
 
 This is a separate variable to `var.secrets` because it is sensitive and therefore cannot be used in a `for_each` loop.
 DESCRIPTION

--- a/variables.tf
+++ b/variables.tf
@@ -454,8 +454,8 @@ The map value is the writable-only secret value for that key.
 
 Use `var.secrets_value_wo_version` with the same key to control updates when the writable-only value changes.
 DESCRIPTION
-  ephemeral   = true
   sensitive   = true
+  ephemeral   = true
 }
 
 variable "secrets_value_wo_version" {


### PR DESCRIPTION
- Introduced `secrets_value_wo` variable for writable-only secrets, including value and version attributes.
- Updated `main.secrets.tf` to handle new writable secret values.
- Modified documentation to reflect changes in variable definitions and usage.
- Adjusted example to demonstrate the new writable secret functionality.

## Description

These changes allow for the support of writable-only secret values, making it possible to create secrets that may or may not be managed by Terraform itself.

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

Fixes #271

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
