### PR TITLE
fix: Add resource to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,10 @@ Description: The name of the key vault.
 
 Description: A map of private endpoints. The map key is the supplied input to var.private\_endpoints. The map value is the entire azurerm\_private\_endpoint resource.
 
+### <a name="output_resource"></a> [resource](#output\_resource)
+
+Description: The full azurerm\_key\_vault resource.
+
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: The Azure resource id of the key vault.

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,6 +32,11 @@ output "private_endpoints" {
   value       = var.private_endpoints_manage_dns_zone_group ? azurerm_private_endpoint.this : azurerm_private_endpoint.this_unmanaged_dns_zone_groups
 }
 
+output "resource" {
+  description = "The full azurerm_key_vault resource."
+  value       = azurerm_key_vault.this
+}
+
 output "resource_id" {
   description = "The Azure resource id of the key vault."
   value       = azurerm_key_vault.this.id


### PR DESCRIPTION
## Description

This PR adds a new module output, resource, that exposes the full azurerm_key_vault.this object so consumers can access complete Key Vault attributes directly from module outputs without needing additional data sources. The existing resource_id output is retained for backward compatibility. The module documentation was also updated to include the new resource output in the Outputs section. 

No additional runtime dependencies were introduced by this change.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
