### PR TITLE
Private endpoint, network interface, and private service connection name correction

### DIFF
--- a/main.private_endpoint.tf
+++ b/main.private_endpoint.tf
@@ -11,7 +11,7 @@ resource "azurerm_private_endpoint" "this" {
 
   private_service_connection {
     is_manual_connection           = false
-    name                           = each.value.private_service_connection_name != null ? each.value.private_service_connection_name : "pse-${var.name}"
+    name                           = each.value.private_service_connection_name != null ? each.value.private_service_connection_name : "psc-${var.name}"
     private_connection_resource_id = azurerm_key_vault.this.id
     subresource_names              = ["vault"]
   }
@@ -48,7 +48,7 @@ resource "azurerm_private_endpoint" "this_unmanaged_dns_zone_groups" {
 
   private_service_connection {
     is_manual_connection           = false
-    name                           = each.value.private_service_connection_name != null ? each.value.private_service_connection_name : "pse-${var.name}"
+    name                           = each.value.private_service_connection_name != null ? each.value.private_service_connection_name : "psc-${var.name}"
     private_connection_resource_id = azurerm_key_vault.this.id
     subresource_names              = ["vault"]
   }

--- a/main.private_endpoint.tf
+++ b/main.private_endpoint.tf
@@ -3,7 +3,7 @@ resource "azurerm_private_endpoint" "this" {
   for_each = { for k, v in var.private_endpoints : k => v if var.private_endpoints_manage_dns_zone_group }
 
   location                      = each.value.location != null ? each.value.location : var.location
-  name                          = each.value.name != null ? each.value.name : "pe-${var.name}"
+  name                          = each.value.name != null ? each.value.name : "pep-${var.name}"
   resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : var.resource_group_name
   subnet_id                     = each.value.subnet_resource_id
   custom_network_interface_name = each.value.network_interface_name
@@ -40,7 +40,7 @@ resource "azurerm_private_endpoint" "this_unmanaged_dns_zone_groups" {
   for_each = { for k, v in var.private_endpoints : k => v if !var.private_endpoints_manage_dns_zone_group }
 
   location                      = each.value.location != null ? each.value.location : var.location
-  name                          = each.value.name != null ? each.value.name : "pe-${var.name}"
+  name                          = each.value.name != null ? each.value.name : "pep-${var.name}"
   resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : var.resource_group_name
   subnet_id                     = each.value.subnet_resource_id
   custom_network_interface_name = each.value.network_interface_name

--- a/main.private_endpoint.tf
+++ b/main.private_endpoint.tf
@@ -6,7 +6,7 @@ resource "azurerm_private_endpoint" "this" {
   name                          = each.value.name != null ? each.value.name : "pep-${var.name}"
   resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : var.resource_group_name
   subnet_id                     = each.value.subnet_resource_id
-  custom_network_interface_name = each.value.network_interface_name
+  custom_network_interface_name = each.value.network_interface_name != null ? each.value.network_interface_name : "nic-pep-${var.name}"
   tags                          = each.value.tags
 
   private_service_connection {
@@ -43,7 +43,7 @@ resource "azurerm_private_endpoint" "this_unmanaged_dns_zone_groups" {
   name                          = each.value.name != null ? each.value.name : "pep-${var.name}"
   resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : var.resource_group_name
   subnet_id                     = each.value.subnet_resource_id
-  custom_network_interface_name = each.value.network_interface_name
+  custom_network_interface_name = each.value.network_interface_name != null ? each.value.network_interface_name : "nic-pep-${var.name}"
   tags                          = each.value.tags
 
   private_service_connection {


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->
This PR proposes 3 corrections:
1. The module currently prefixes private endpoints with `pe`. The correct abbreviation according to Microsoft documentation is `pep`. Organisations globally will be using Microsoft recommendations so this module should not stray from this default.
Source: https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations#networking

2. The network interface name is currently randomly generated and looks something like `pe-kv123.nic.a2b917e7-1c71-4c9a-b28b-a707f0a620c7`. This does not follow any normal naming convention and should be corrected. The correct/normal standard for a nic would be something like `nic-pep-kv123`. With this naming it is clear that it is a Network Interface for a Private Endpoint.

3. For some reason the initial authoring of this module has use `pse` to prefix private service connections. Although there is no official documented abbreviation for private service connection, it would make sense to correct this to `psc`.

This is a breaking change since it would force the recreation of these resources unless the values were explicitly passed. therefore in the release notes we should make this clear. This is an important change to implement before this module reaches v1 to ensure we are adopting Microsoft-recommended abbreviations and standard/common patterns in our community rather than random/unusual resource naming.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [X] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [X] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
