### PR TITLE
fix: correct keys/secrets output descriptions and expose key public material attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,13 +539,19 @@ The following outputs are exported:
 
 ### <a name="output_keys"></a> [keys](#output\_keys)
 
-Description: A map of key keys to key values. The key value is the entire azurerm\_key\_vault\_key resource.
+Description: A map of key keys to key values. The key value is not the entire azurerm\_key\_vault\_key resource, only the attributes listed below are exposed.
 
 The key value contains the following attributes:
+- e: The RSA public exponent of the key. Empty for EC keys.
 - id: The Key Vault Key ID
+- n: The RSA modulus of the key. Empty for EC keys.
+- public\_key\_openssh: The OpenSSH encoded public key of the key.
+- public\_key\_pem: The PEM encoded public key of the key.
 - resource\_id: The Azure resource id of the key.
 - resource\_versionless\_id: The versionless Azure resource id of the key.
 - versionless\_id: The Base ID of the Key Vault Key
+- x: The EC X component of the key. Empty for RSA keys.
+- y: The EC Y component of the key. Empty for RSA keys.
 
 ### <a name="output_keys_resource_ids"></a> [keys\_resource\_ids](#output\_keys\_resource\_ids)
 
@@ -565,7 +571,7 @@ Description: The Azure resource id of the key vault.
 
 ### <a name="output_secrets"></a> [secrets](#output\_secrets)
 
-Description: A map of secret keys to secret values. The secret value is the entire azurerm\_key\_vault\_secret resource.
+Description: A map of secret keys to secret values. The secret value is not the entire azurerm\_key\_vault\_secret resource, only the attributes listed below are exposed.
 
 The secret value contains the following attributes:
 - id: The Key Vault Secret ID

--- a/README.md
+++ b/README.md
@@ -541,18 +541,26 @@ The following outputs are exported:
 
 Description: A map of key keys to key values. The key value is not the entire azurerm\_key\_vault\_key resource, only the attributes listed below are exposed.
 
-The key value contains the following attributes:
-- e: The RSA public exponent of the key. Empty for EC keys.
+The key value contains the following attributes, grouped by purpose:
+
+Identifiers:
 - id: The Key Vault Key ID
-- n: The RSA modulus of the key. Empty for EC keys.
 - name: The name of the key.
-- public\_key\_openssh: The OpenSSH encoded public key of the key. Empty for `P-256K` keys.
-- public\_key\_pem: The PEM encoded public key of the key. Empty for `P-256K` keys.
 - resource\_id: The Azure resource id of the key.
 - resource\_versionless\_id: The versionless Azure resource id of the key.
 - versionless\_id: The Base ID of the Key Vault Key
-- x: The EC X component of the key. Empty for RSA keys.
-- y: The EC Y component of the key. Empty for RSA keys.
+
+Encoded public key, for RSA and for EC curves other than `P-256K`:
+- public\_key\_pem: The PEM encoded public key of the key.
+- public\_key\_openssh: The OpenSSH encoded public key of the key.
+
+Raw RSA public key components, empty for EC keys. These are a pair:
+- n: The RSA modulus of the key.
+- e: The RSA public exponent of the key.
+
+Raw EC public key components, empty for RSA keys. These are a pair:
+- x: The EC X component of the key.
+- y: The EC Y component of the key.
 
 ### <a name="output_keys_resource_ids"></a> [keys\_resource\_ids](#output\_keys\_resource\_ids)
 

--- a/README.md
+++ b/README.md
@@ -546,8 +546,8 @@ The key value contains the following attributes:
 - id: The Key Vault Key ID
 - n: The RSA modulus of the key. Empty for EC keys.
 - name: The name of the key.
-- public\_key\_openssh: The OpenSSH encoded public key of the key.
-- public\_key\_pem: The PEM encoded public key of the key.
+- public\_key\_openssh: The OpenSSH encoded public key of the key. Empty for `P-256K` keys.
+- public\_key\_pem: The PEM encoded public key of the key. Empty for `P-256K` keys.
 - resource\_id: The Azure resource id of the key.
 - resource\_versionless\_id: The versionless Azure resource id of the key.
 - versionless\_id: The Base ID of the Key Vault Key

--- a/modules/key/README.md
+++ b/modules/key/README.md
@@ -204,19 +204,19 @@ Description: The name of the Key Vault Key.
 
 ### <a name="output_public_key_openssh"></a> [public\_key\_openssh](#output\_public\_key\_openssh)
 
-Description: The OpenSSH encoded public key of the Key Vault Key.
+Description: The OpenSSH encoded public key of the Key Vault Key. Empty for `P-256K` keys, which the provider does not derive a public key for.
 
 ### <a name="output_public_key_pem"></a> [public\_key\_pem](#output\_public\_key\_pem)
 
-Description: The PEM encoded public key of the Key Vault Key.
+Description: The PEM encoded public key of the Key Vault Key. Empty for `P-256K` keys, which the provider does not derive a public key for.
 
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
-Description: The Azure resource id of the secret.
+Description: The Azure resource id of the key.
 
 ### <a name="output_resource_versionless_id"></a> [resource\_versionless\_id](#output\_resource\_versionless\_id)
 
-Description: The versionless Azure resource id of the secret.
+Description: The versionless Azure resource id of the key.
 
 ### <a name="output_versionless_id"></a> [versionless\_id](#output\_versionless\_id)
 

--- a/modules/key/README.md
+++ b/modules/key/README.md
@@ -154,9 +154,25 @@ Default: `null`
 
 The following outputs are exported:
 
+### <a name="output_e"></a> [e](#output\_e)
+
+Description: The RSA public exponent of the Key Vault Key. Empty for EC keys.
+
 ### <a name="output_id"></a> [id](#output\_id)
 
 Description: The Key Vault Key ID
+
+### <a name="output_n"></a> [n](#output\_n)
+
+Description: The RSA modulus of the Key Vault Key. Empty for EC keys.
+
+### <a name="output_public_key_openssh"></a> [public\_key\_openssh](#output\_public\_key\_openssh)
+
+Description: The OpenSSH encoded public key of the Key Vault Key.
+
+### <a name="output_public_key_pem"></a> [public\_key\_pem](#output\_public\_key\_pem)
+
+Description: The PEM encoded public key of the Key Vault Key.
 
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
@@ -169,6 +185,14 @@ Description: The versionless Azure resource id of the secret.
 ### <a name="output_versionless_id"></a> [versionless\_id](#output\_versionless\_id)
 
 Description: The Base ID of the Key Vault Key
+
+### <a name="output_x"></a> [x](#output\_x)
+
+Description: The EC X component of the Key Vault Key. Empty for RSA keys.
+
+### <a name="output_y"></a> [y](#output\_y)
+
+Description: The EC Y component of the Key Vault Key. Empty for RSA keys.
 
 ## Modules
 

--- a/modules/key/README.md
+++ b/modules/key/README.md
@@ -188,7 +188,7 @@ The following outputs are exported:
 
 ### <a name="output_e"></a> [e](#output\_e)
 
-Description: The RSA public exponent of the Key Vault Key. Empty for EC keys.
+Description: The RSA public exponent of the Key Vault Key. Use together with `n`, which carries the modulus. Empty for EC keys.
 
 ### <a name="output_id"></a> [id](#output\_id)
 
@@ -196,7 +196,7 @@ Description: The Key Vault Key ID
 
 ### <a name="output_n"></a> [n](#output\_n)
 
-Description: The RSA modulus of the Key Vault Key. Empty for EC keys.
+Description: The RSA modulus of the Key Vault Key. Use together with `e`, which carries the public exponent. Empty for EC keys.
 
 ### <a name="output_name"></a> [name](#output\_name)
 
@@ -224,11 +224,11 @@ Description: The Base ID of the Key Vault Key
 
 ### <a name="output_x"></a> [x](#output\_x)
 
-Description: The EC X component of the Key Vault Key. Empty for RSA keys.
+Description: The EC X component of the Key Vault Key. Use together with `y`, which carries the Y component. Empty for RSA keys.
 
 ### <a name="output_y"></a> [y](#output\_y)
 
-Description: The EC Y component of the Key Vault Key. Empty for RSA keys.
+Description: The EC Y component of the Key Vault Key. Use together with `x`, which carries the X component. Empty for RSA keys.
 
 ## Modules
 

--- a/modules/key/outputs.tf
+++ b/modules/key/outputs.tf
@@ -19,22 +19,22 @@ output "name" {
 }
 
 output "public_key_openssh" {
-  description = "The OpenSSH encoded public key of the Key Vault Key."
+  description = "The OpenSSH encoded public key of the Key Vault Key. Empty for `P-256K` keys, which the provider does not derive a public key for."
   value       = azurerm_key_vault_key.this.public_key_openssh
 }
 
 output "public_key_pem" {
-  description = "The PEM encoded public key of the Key Vault Key."
+  description = "The PEM encoded public key of the Key Vault Key. Empty for `P-256K` keys, which the provider does not derive a public key for."
   value       = azurerm_key_vault_key.this.public_key_pem
 }
 
 output "resource_id" {
-  description = "The Azure resource id of the secret."
+  description = "The Azure resource id of the key."
   value       = azurerm_key_vault_key.this.resource_id
 }
 
 output "resource_versionless_id" {
-  description = "The versionless Azure resource id of the secret."
+  description = "The versionless Azure resource id of the key."
   value       = azurerm_key_vault_key.this.resource_versionless_id
 }
 

--- a/modules/key/outputs.tf
+++ b/modules/key/outputs.tf
@@ -1,5 +1,5 @@
 output "e" {
-  description = "The RSA public exponent of the Key Vault Key. Empty for EC keys."
+  description = "The RSA public exponent of the Key Vault Key. Use together with `n`, which carries the modulus. Empty for EC keys."
   value       = azurerm_key_vault_key.this.e
 }
 
@@ -9,7 +9,7 @@ output "id" {
 }
 
 output "n" {
-  description = "The RSA modulus of the Key Vault Key. Empty for EC keys."
+  description = "The RSA modulus of the Key Vault Key. Use together with `e`, which carries the public exponent. Empty for EC keys."
   value       = azurerm_key_vault_key.this.n
 }
 
@@ -44,11 +44,11 @@ output "versionless_id" {
 }
 
 output "x" {
-  description = "The EC X component of the Key Vault Key. Empty for RSA keys."
+  description = "The EC X component of the Key Vault Key. Use together with `y`, which carries the Y component. Empty for RSA keys."
   value       = azurerm_key_vault_key.this.x
 }
 
 output "y" {
-  description = "The EC Y component of the Key Vault Key. Empty for RSA keys."
+  description = "The EC Y component of the Key Vault Key. Use together with `x`, which carries the X component. Empty for RSA keys."
   value       = azurerm_key_vault_key.this.y
 }

--- a/modules/key/outputs.tf
+++ b/modules/key/outputs.tf
@@ -1,6 +1,26 @@
+output "e" {
+  description = "The RSA public exponent of the Key Vault Key. Empty for EC keys."
+  value       = azurerm_key_vault_key.this.e
+}
+
 output "id" {
   description = "The Key Vault Key ID"
   value       = azurerm_key_vault_key.this.id
+}
+
+output "n" {
+  description = "The RSA modulus of the Key Vault Key. Empty for EC keys."
+  value       = azurerm_key_vault_key.this.n
+}
+
+output "public_key_openssh" {
+  description = "The OpenSSH encoded public key of the Key Vault Key."
+  value       = azurerm_key_vault_key.this.public_key_openssh
+}
+
+output "public_key_pem" {
+  description = "The PEM encoded public key of the Key Vault Key."
+  value       = azurerm_key_vault_key.this.public_key_pem
 }
 
 output "resource_id" {
@@ -16,4 +36,14 @@ output "resource_versionless_id" {
 output "versionless_id" {
   description = "The Base ID of the Key Vault Key"
   value       = azurerm_key_vault_key.this.versionless_id
+}
+
+output "x" {
+  description = "The EC X component of the Key Vault Key. Empty for RSA keys."
+  value       = azurerm_key_vault_key.this.x
+}
+
+output "y" {
+  description = "The EC Y component of the Key Vault Key. Empty for RSA keys."
+  value       = azurerm_key_vault_key.this.y
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,12 +1,18 @@
 output "keys" {
   description = <<DESCRIPTION
-A map of key keys to key values. The key value is the entire azurerm_key_vault_key resource.
+A map of key keys to key values. The key value is not the entire azurerm_key_vault_key resource, only the attributes listed below are exposed.
 
 The key value contains the following attributes:
+- e: The RSA public exponent of the key. Empty for EC keys.
 - id: The Key Vault Key ID
+- n: The RSA modulus of the key. Empty for EC keys.
+- public_key_openssh: The OpenSSH encoded public key of the key.
+- public_key_pem: The PEM encoded public key of the key.
 - resource_id: The Azure resource id of the key.
 - resource_versionless_id: The versionless Azure resource id of the key.
 - versionless_id: The Base ID of the Key Vault Key
+- x: The EC X component of the key. Empty for RSA keys.
+- y: The EC Y component of the key. Empty for RSA keys.
 DESCRIPTION
   value       = module.keys
 }
@@ -39,7 +45,7 @@ output "resource_id" {
 
 output "secrets" {
   description = <<DESCRIPTION
-A map of secret keys to secret values. The secret value is the entire azurerm_key_vault_secret resource.
+A map of secret keys to secret values. The secret value is not the entire azurerm_key_vault_secret resource, only the attributes listed below are exposed.
 
 The secret value contains the following attributes:
 - id: The Key Vault Secret ID

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,18 +2,26 @@ output "keys" {
   description = <<DESCRIPTION
 A map of key keys to key values. The key value is not the entire azurerm_key_vault_key resource, only the attributes listed below are exposed.
 
-The key value contains the following attributes:
-- e: The RSA public exponent of the key. Empty for EC keys.
+The key value contains the following attributes, grouped by purpose:
+
+Identifiers:
 - id: The Key Vault Key ID
-- n: The RSA modulus of the key. Empty for EC keys.
 - name: The name of the key.
-- public_key_openssh: The OpenSSH encoded public key of the key. Empty for `P-256K` keys.
-- public_key_pem: The PEM encoded public key of the key. Empty for `P-256K` keys.
 - resource_id: The Azure resource id of the key.
 - resource_versionless_id: The versionless Azure resource id of the key.
 - versionless_id: The Base ID of the Key Vault Key
-- x: The EC X component of the key. Empty for RSA keys.
-- y: The EC Y component of the key. Empty for RSA keys.
+
+Encoded public key, for RSA and for EC curves other than `P-256K`:
+- public_key_pem: The PEM encoded public key of the key.
+- public_key_openssh: The OpenSSH encoded public key of the key.
+
+Raw RSA public key components, empty for EC keys. These are a pair:
+- n: The RSA modulus of the key.
+- e: The RSA public exponent of the key.
+
+Raw EC public key components, empty for RSA keys. These are a pair:
+- x: The EC X component of the key.
+- y: The EC Y component of the key.
 DESCRIPTION
   value       = module.keys
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,8 +7,8 @@ The key value contains the following attributes:
 - id: The Key Vault Key ID
 - n: The RSA modulus of the key. Empty for EC keys.
 - name: The name of the key.
-- public_key_openssh: The OpenSSH encoded public key of the key.
-- public_key_pem: The PEM encoded public key of the key.
+- public_key_openssh: The OpenSSH encoded public key of the key. Empty for `P-256K` keys.
+- public_key_pem: The PEM encoded public key of the key. Empty for `P-256K` keys.
 - resource_id: The Azure resource id of the key.
 - resource_versionless_id: The versionless Azure resource id of the key.
 - versionless_id: The Base ID of the Key Vault Key
@@ -21,11 +21,11 @@ DESCRIPTION
 output "keys_resource_ids" {
   description = "A map of key keys to resource ids and key names."
   value = { for kk, kv in module.keys : kk => {
+    id                      = kv.id
+    name                    = kv.name
     resource_id             = kv.resource_id
     resource_versionless_id = kv.resource_versionless_id
-    id                      = kv.id
     versionless_id          = kv.versionless_id
-    name                    = kv.name
     }
   }
 }
@@ -62,11 +62,11 @@ DESCRIPTION
 output "secrets_resource_ids" {
   description = "A map of secret keys to resource ids and secret names."
   value = { for sk, sv in module.secrets : sk => {
+    id                      = sv.id
+    name                    = sv.name
     resource_id             = sv.resource_id
     resource_versionless_id = sv.resource_versionless_id
-    id                      = sv.id
     versionless_id          = sv.versionless_id
-    name                    = sv.name
     }
   }
 }


### PR DESCRIPTION
Fixes #269

## What was wrong

The root `keys` output description claimed:

> A map of key keys to key values. **The key value is the entire azurerm_key_vault_key resource.**

That was never true — `module.keys` only ever exposed the four outputs declared in `modules/key/outputs.tf`. The `secrets` output carried the identical false claim about `azurerm_key_vault_secret`. Both descriptions are now accurate.

## What was added

Per @matt-FFFFFF's ruling on the issue, and per AVM spec **[TFFR2 – Additional Terraform Outputs](https://azure.github.io/Azure-Verified-Modules/spec/TFFR2)** ("Authors **SHOULD NOT** output entire resource objects… Instead, authors **SHOULD** output the *computed* attributes of the resource as discreet outputs"), this does not return the whole resource. Instead `modules/key/outputs.tf` now exposes the six requested computed attributes:

| Output | Description |
| --- | --- |
| `n` | RSA modulus (empty for EC keys) |
| `e` | RSA public exponent (empty for EC keys) |
| `x` | EC X component (empty for RSA keys) |
| `y` | EC Y component (empty for RSA keys) |
| `public_key_pem` | PEM encoded public key |
| `public_key_openssh` | OpenSSH encoded public key |

These flow into the root `keys` output automatically, since its value is `module.keys`.

## Notes for reviewers

- **Provider floor verified.** All six attributes exist as `Computed: true` strings in `internal/services/keyvault/key_vault_key_resource.go` at tag `v3.117.0`, which is the declared floor in both `terraform.tf` files. No constraint bump needed.
- **Not sensitive.** These are public key material only, so no `sensitive = true` and no change to the sensitivity of the aggregate `keys` output.
- **`keys_resource_ids` deliberately left alone.** Adding public key material to an output named `*_resource_ids` would be misleading — it's explicitly "a map of key keys to resource ids". Consumers get the new attributes from `keys`. Happy to change this if you disagree.
- **No secret outputs added.** #269 asks nothing for secrets, and the secret `value` is sensitive by design — only the false sentence was removed.
- **Out of scope:** #210 (`name` output on keys/secrets) is being handled separately, so no `name` output here. `version` is also computed and unexposed but wasn't requested — easy follow-up if wanted.
- Additive and non-breaking → minor bump.

## Validation

- `terraform fmt -recursive -check` — clean
- `terraform validate` — clean
- `terraform test -test-directory=tests/unit` — **10 passed, 0 failed**
- READMEs regenerated with `terraform-docs -c .terraform-docs.yml` for the root and `modules/key` (`recursive` is disabled in the config, so they generate separately). Docker wasn't available locally, so `./avm pr-check` will run in CI.

_Drafted by Claude Opus 5._
