### PR TITLE
feat: expose secret and key names in module outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,13 +543,14 @@ Description: A map of key keys to key values. The key value is the entire azurer
 
 The key value contains the following attributes:
 - id: The Key Vault Key ID
+- name: The name of the key.
 - resource\_id: The Azure resource id of the key.
 - resource\_versionless\_id: The versionless Azure resource id of the key.
 - versionless\_id: The Base ID of the Key Vault Key
 
 ### <a name="output_keys_resource_ids"></a> [keys\_resource\_ids](#output\_keys\_resource\_ids)
 
-Description: A map of key keys to resource ids.
+Description: A map of key keys to resource ids and key names.
 
 ### <a name="output_name"></a> [name](#output\_name)
 
@@ -569,13 +570,14 @@ Description: A map of secret keys to secret values. The secret value is the enti
 
 The secret value contains the following attributes:
 - id: The Key Vault Secret ID
+- name: The name of the secret.
 - resource\_id: The Azure resource id of the secret.
 - resource\_versionless\_id: The versionless Azure resource id of the secret.
 - versionless\_id: The Base ID of the Key Vault Secret
 
 ### <a name="output_secrets_resource_ids"></a> [secrets\_resource\_ids](#output\_secrets\_resource\_ids)
 
-Description: A map of secret keys to resource ids.
+Description: A map of secret keys to resource ids and secret names.
 
 ### <a name="output_uri"></a> [uri](#output\_uri)
 

--- a/modules/key/README.md
+++ b/modules/key/README.md
@@ -158,6 +158,10 @@ The following outputs are exported:
 
 Description: The Key Vault Key ID
 
+### <a name="output_name"></a> [name](#output\_name)
+
+Description: The name of the Key Vault Key.
+
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: The Azure resource id of the secret.

--- a/modules/key/outputs.tf
+++ b/modules/key/outputs.tf
@@ -3,6 +3,11 @@ output "id" {
   value       = azurerm_key_vault_key.this.id
 }
 
+output "name" {
+  description = "The name of the Key Vault Key."
+  value       = azurerm_key_vault_key.this.name
+}
+
 output "resource_id" {
   description = "The Azure resource id of the secret."
   value       = azurerm_key_vault_key.this.resource_id

--- a/modules/secret/README.md
+++ b/modules/secret/README.md
@@ -117,6 +117,10 @@ The following outputs are exported:
 
 Description: The Key Vault Secret ID
 
+### <a name="output_name"></a> [name](#output\_name)
+
+Description: The name of the Key Vault Secret.
+
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: The Azure resource id of the secret.

--- a/modules/secret/outputs.tf
+++ b/modules/secret/outputs.tf
@@ -3,6 +3,11 @@ output "id" {
   value       = azurerm_key_vault_secret.this.id
 }
 
+output "name" {
+  description = "The name of the Key Vault Secret."
+  value       = azurerm_key_vault_secret.this.name
+}
+
 output "resource_id" {
   description = "The Azure resource id of the secret."
   value       = azurerm_key_vault_secret.this.resource_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,6 +4,7 @@ A map of key keys to key values. The key value is the entire azurerm_key_vault_k
 
 The key value contains the following attributes:
 - id: The Key Vault Key ID
+- name: The name of the key.
 - resource_id: The Azure resource id of the key.
 - resource_versionless_id: The versionless Azure resource id of the key.
 - versionless_id: The Base ID of the Key Vault Key
@@ -12,12 +13,13 @@ DESCRIPTION
 }
 
 output "keys_resource_ids" {
-  description = "A map of key keys to resource ids."
+  description = "A map of key keys to resource ids and key names."
   value = { for kk, kv in module.keys : kk => {
     resource_id             = kv.resource_id
     resource_versionless_id = kv.resource_versionless_id
     id                      = kv.id
     versionless_id          = kv.versionless_id
+    name                    = kv.name
     }
   }
 }
@@ -43,6 +45,7 @@ A map of secret keys to secret values. The secret value is the entire azurerm_ke
 
 The secret value contains the following attributes:
 - id: The Key Vault Secret ID
+- name: The name of the secret.
 - resource_id: The Azure resource id of the secret.
 - resource_versionless_id: The versionless Azure resource id of the secret.
 - versionless_id: The Base ID of the Key Vault Secret
@@ -51,12 +54,13 @@ DESCRIPTION
 }
 
 output "secrets_resource_ids" {
-  description = "A map of secret keys to resource ids."
+  description = "A map of secret keys to resource ids and secret names."
   value = { for sk, sv in module.secrets : sk => {
     resource_id             = sv.resource_id
     resource_versionless_id = sv.resource_versionless_id
     id                      = sv.id
     versionless_id          = sv.versionless_id
+    name                    = sv.name
     }
   }
 }


### PR DESCRIPTION
## Problem

The map key used in `var.secrets` / `var.keys` is a *symbolic* name that is independent of the actual resource name:

```hcl
secrets = {
  test_secret = {          # symbolic key
    name = "test-secret"   # actual secret name
  }
}
```

The submodules only exported `id`, `resource_id`, `resource_versionless_id` and `versionless_id`, so consumers had no way to recover the real name from the module outputs other than string-munging a resource id (`basename(...versionless_id)`, the interim workaround suggested in #210).

For **keys** this is worse than cosmetic: as noted in a follow-up comment on #210, deriving the name from the id pulls the id into the plan and produces extra churn whenever Terraform recreates the key.

## Changes

- `output "name"` added to `modules/secret/outputs.tf` and `modules/key/outputs.tf`.
- Because the root `secrets` and `keys` outputs are bare passthroughs of `module.secrets` / `module.keys`, the new attribute surfaces there automatically. Their heredoc descriptions are updated to list it.
- `name` added to the explicitly-constructed `secrets_resource_ids` / `keys_resource_ids` maps as well. Those maps currently mirror the submodule output set exactly, so omitting `name` would have silently diverged them; their descriptions now say "resource ids and ... names" rather than leaving it undocumented.
- READMEs regenerated (root + both submodules).

Before:

```hcl
basename(module.key_vault.secrets_resource_ids["test_secret"].versionless_id)
```

After:

```hcl
module.key_vault.secrets["test_secret"].name
# or
module.key_vault.secrets_resource_ids["test_secret"].name
```

Additive only — no breaking changes. `.name` is available on both `azurerm_key_vault_secret` and `azurerm_key_vault_key` across the whole pinned `azurerm >= 3.117, < 5.0` range.

## Supersedes #246

Draft PR #246 covered the same ground for secrets only. This PR supersedes it: it also covers keys (which #210's comment thread explicitly asks for), regenerates the docs, and drops #246's `terraform fmt`-violating demo output in `examples/create-secret`.

## Validation

- `terraform fmt -recursive -check` — clean
- `terraform validate` — success
- `terraform test -test-directory=tests/unit` — 10 passed, 0 failed
- `terraform-docs` regeneration produces no further diff

No `terraform apply` run locally.

## Note for reviewers

#269 asks for the *full* `azurerm_key_vault_key` attribute set on `modules/key/outputs.tf`. This PR is the minimal fix for #210; whichever lands second will need a trivial rebase there.

Fixes #210

_Drafted by Claude Opus 5._
