### PR TITLE
docs: add registry usage examples to key/secret submodule docs

### DIFF
--- a/modules/key/README.md
+++ b/modules/key/README.md
@@ -4,6 +4,38 @@
 
 Module to deploy key vault keys.
 
+## Usage
+
+This sub-module can be called directly to add keys to an existing key vault:
+
+```terraform
+module "keyvault_key" {
+  source  = "Azure/avm-res-keyvault-vault/azurerm//modules/key"
+  version = "0.10.2"
+
+  key_vault_resource_id = azurerm_key_vault.this.id
+  name                  = "my-key"
+  type                  = "RSA"
+
+  # Optional
+  size = 2048
+  opts = ["sign", "verify"]
+  rotation_policy = {
+    automatic = {
+      time_before_expiry = "P30D"
+    }
+    expire_after         = "P90D"
+    notify_before_expiry = "P29D"
+  }
+  role_assignments = {
+    crypto_user = {
+      role_definition_id_or_name = "Key Vault Crypto User"
+      principal_id               = data.azurerm_client_config.this.object_id
+    }
+  }
+}
+```
+
 <!-- markdownlint-disable MD033 -->
 ## Requirements
 

--- a/modules/key/_header.md
+++ b/modules/key/_header.md
@@ -1,3 +1,35 @@
 # terraform-azurerm-avm-res-keyvault-vault//key
 
 Module to deploy key vault keys.
+
+## Usage
+
+This sub-module can be called directly to add keys to an existing key vault:
+
+```terraform
+module "keyvault_key" {
+  source  = "Azure/avm-res-keyvault-vault/azurerm//modules/key"
+  version = "0.10.2"
+
+  key_vault_resource_id = azurerm_key_vault.this.id
+  name                  = "my-key"
+  type                  = "RSA"
+
+  # Optional
+  size = 2048
+  opts = ["sign", "verify"]
+  rotation_policy = {
+    automatic = {
+      time_before_expiry = "P30D"
+    }
+    expire_after         = "P90D"
+    notify_before_expiry = "P29D"
+  }
+  role_assignments = {
+    crypto_user = {
+      role_definition_id_or_name = "Key Vault Crypto User"
+      principal_id               = data.azurerm_client_config.this.object_id
+    }
+  }
+}
+```

--- a/modules/secret/README.md
+++ b/modules/secret/README.md
@@ -4,6 +4,33 @@
 
 Module to deploy key vault secrets in Azure.
 
+## Usage
+
+This sub-module can be called directly to add secrets to an existing key vault:
+
+```terraform
+module "keyvault_secret" {
+  source  = "Azure/avm-res-keyvault-vault/azurerm//modules/secret"
+  version = "0.10.2"
+
+  key_vault_resource_id = azurerm_key_vault.this.id
+  name                  = "my-secret"
+  value                 = "my-secret-value"
+
+  # Optional
+  content_type = "text/plain"
+  tags = {
+    environment = "prod"
+  }
+  role_assignments = {
+    secrets_user = {
+      role_definition_id_or_name = "Key Vault Secrets User"
+      principal_id               = data.azurerm_client_config.this.object_id
+    }
+  }
+}
+```
+
 <!-- markdownlint-disable MD033 -->
 ## Requirements
 

--- a/modules/secret/_header.md
+++ b/modules/secret/_header.md
@@ -1,3 +1,30 @@
 # terraform-azurerm-avm-res-keyvault-vault//secret
 
 Module to deploy key vault secrets in Azure.
+
+## Usage
+
+This sub-module can be called directly to add secrets to an existing key vault:
+
+```terraform
+module "keyvault_secret" {
+  source  = "Azure/avm-res-keyvault-vault/azurerm//modules/secret"
+  version = "0.10.2"
+
+  key_vault_resource_id = azurerm_key_vault.this.id
+  name                  = "my-secret"
+  value                 = "my-secret-value"
+
+  # Optional
+  content_type = "text/plain"
+  tags = {
+    environment = "prod"
+  }
+  role_assignments = {
+    secrets_user = {
+      role_definition_id_or_name = "Key Vault Secrets User"
+      principal_id               = data.azurerm_client_config.this.object_id
+    }
+  }
+}
+```


### PR DESCRIPTION
Fixes #204

The generated READMEs for `modules/key` and `modules/secret` never showed consumers how to actually *call* the submodules. PR #256 removed the `{{ include "main.tf" }}` directive that was dumping the submodule's own implementation into the README, but that left the docs with no usage example at all — just a title and a one-line description.

This adds a `## Usage` section to each submodule's `_header.md` (the `header-from` source in `modules/.terraform-docs.yml`) and regenerates the READMEs.

### Details

- **Registry source path.** The issue reporter guessed `Azure/terraform-azurerm-avm-res-keyvault-vault/azurerm//modules/secret`, which would not resolve — that's the GitHub repo name. The published module is `Azure/avm-res-keyvault-vault/azurerm`, so the correct sources are `Azure/avm-res-keyvault-vault/azurerm//modules/key` and `//modules/secret`. Confirmed against registry.terraform.io.
- **Version pin** is `0.10.2`, the current published release.
- **Inputs are real, not invented** — taken from each submodule's `variables.tf`. `secret` requires `key_vault_resource_id` / `name` / `value`; `key` requires `key_vault_resource_id` / `name` / `type` (plus `size` for RSA). Both examples pass `azurerm_key_vault.this.id` because `key_vault_resource_id` validates against a full `/subscriptions/.../vaults/<name>` resource ID regex. Optional blocks (`role_assignments`, `rotation_policy`, `tags`, `content_type`) are shown too, as the issue asked for.

### Validation

- READMEs regenerated with `terraform-docs -c ../.terraform-docs.yml .` in each submodule directory. Docker wasn't available locally so `./avm pre-commit` couldn't run; the root `.terraform-docs.yml` has `recursive.enabled: false`, so the per-submodule invocation is the equivalent path. CI's docs checks confirm the output is identical.
- Both examples extracted and checked with `terraform fmt -check -diff` — clean.
- Diff is additions only; no unrelated churn in the generated files.

### Note

The `check mapotf` failure in PR Check is pre-existing drift on `main` in `main.tf`, `main.telemetry.tf` and `main.private_endpoint.tf` — files this PR does not touch. Tracked in #311.

The hardcoded `0.10.2` will drift on future releases since nothing auto-bumps `_header.md`. Tracked separately in #312 — it applies to any version pin baked into an `_header.md`, not just the two added here.

_Drafted by Claude Opus 5._
