### PR TITLE
chore: run pre-commit to fix mapotf drift blocking all PRs

### DIFF
--- a/main.private_endpoint.tf
+++ b/main.private_endpoint.tf
@@ -15,6 +15,7 @@ resource "azurerm_private_endpoint" "this" {
     private_connection_resource_id = azurerm_key_vault.this.id
     subresource_names              = ["vault"]
   }
+
   dynamic "ip_configuration" {
     for_each = each.value.ip_configurations
 
@@ -25,6 +26,7 @@ resource "azurerm_private_endpoint" "this" {
       subresource_name   = "vault"
     }
   }
+
   dynamic "private_dns_zone_group" {
     for_each = length(each.value.private_dns_zone_resource_ids) > 0 ? ["this"] : []
 
@@ -52,6 +54,7 @@ resource "azurerm_private_endpoint" "this_unmanaged_dns_zone_groups" {
     private_connection_resource_id = azurerm_key_vault.this.id
     subresource_names              = ["vault"]
   }
+
   dynamic "ip_configuration" {
     for_each = each.value.ip_configurations
 

--- a/main.telemetry.tf
+++ b/main.telemetry.tf
@@ -1,4 +1,3 @@
-
 data "modtm_module_source" "telemetry" {
   count = var.enable_telemetry ? 1 : 0
 
@@ -20,6 +19,7 @@ resource "modtm_telemetry" "telemetry" {
     random_id       = one(random_uuid.telemetry).result
   }, { location = local.main_location })
 }
+
 locals {
   main_location = var.location
 }

--- a/main.tf
+++ b/main.tf
@@ -75,6 +75,7 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
       category_group = enabled_log.value
     }
   }
+
   dynamic "metric" {
     for_each = each.value.metric_categories
 


### PR DESCRIPTION
## Description

`PR Check (Lint, Format, Validate)` currently fails on `main` at the `check mapotf` step, which blocks CI on **every** open PR regardless of its content:

```
✗ check mapotf (exit code: -1)
  ✓ mapotf transform
  ✗ Check for mapotf changes (exit code: 1)
    ➜ Error Output:
       Mapotf changes found, run pre-commit
        M main.private_endpoint.tf
        M main.telemetry.tf
        M main.tf
```

These files were last regenerated in #244, but several `chore: sync managed files` commits have landed since. The managed AVM tooling moved on and the committed transform output was never refreshed.

## Changes

Regenerated the mapotf-managed files by running the same transform the pre-commit pipeline runs:

```
mapotf transform --mptf-dir "git::https://github.com/Azure/avm-terraform-governance.git//mapotf-configs/pre-commit" --tf-dir .
mapotf clean-backup --tf-dir .
```

**The diff is whitespace-only** — blank line separators added between blocks, and one leading blank line removed. There is no semantic or behavioural change: no resource arguments, expressions, variables or outputs are touched. Five insertions, one deletion, confined to exactly the three files CI names.

## Verification

Run against a clean clone of `main` at `2f1df9ee8`, with the resulting diff reviewed line by line before committing. `git status` afterwards showed only those three files modified — nothing unexpected.

CI's own containerised `check mapotf` on this PR is the authoritative check: if it goes green, the committed output matches what the pipeline generates.

> [!NOTE]
> Generated with a locally built `mapotf` v0.1.5 rather than via `./avm pre-commit`, because Docker was not available in the authoring environment. If CI still reports drift, the container pins a different mapotf version and this will need regenerating with `./avm pre-commit` on a machine with Docker.

## Unblocks

#306, #307, #308, #309, #310

Fixes #311

_Drafted by Claude Opus 5._
