### PR TITLE
docs: drop version pins from submodule usage examples

### DIFF
--- a/modules/key/README.md
+++ b/modules/key/README.md
@@ -10,8 +10,7 @@ This sub-module can be called directly to add keys to an existing key vault:
 
 ```terraform
 module "keyvault_key" {
-  source  = "Azure/avm-res-keyvault-vault/azurerm//modules/key"
-  version = "0.10.2"
+  source = "Azure/avm-res-keyvault-vault/azurerm//modules/key"
 
   key_vault_resource_id = azurerm_key_vault.this.id
   name                  = "my-key"

--- a/modules/key/README.md
+++ b/modules/key/README.md
@@ -10,7 +10,8 @@ This sub-module can be called directly to add keys to an existing key vault:
 
 ```terraform
 module "keyvault_key" {
-  source = "Azure/avm-res-keyvault-vault/azurerm//modules/key"
+  source  = "Azure/avm-res-keyvault-vault/azurerm//modules/key"
+  version = "0.#.#" # Replace with your desired version
 
   key_vault_resource_id = azurerm_key_vault.this.id
   name                  = "my-key"

--- a/modules/key/_header.md
+++ b/modules/key/_header.md
@@ -8,8 +8,7 @@ This sub-module can be called directly to add keys to an existing key vault:
 
 ```terraform
 module "keyvault_key" {
-  source  = "Azure/avm-res-keyvault-vault/azurerm//modules/key"
-  version = "0.10.2"
+  source = "Azure/avm-res-keyvault-vault/azurerm//modules/key"
 
   key_vault_resource_id = azurerm_key_vault.this.id
   name                  = "my-key"

--- a/modules/key/_header.md
+++ b/modules/key/_header.md
@@ -8,7 +8,8 @@ This sub-module can be called directly to add keys to an existing key vault:
 
 ```terraform
 module "keyvault_key" {
-  source = "Azure/avm-res-keyvault-vault/azurerm//modules/key"
+  source  = "Azure/avm-res-keyvault-vault/azurerm//modules/key"
+  version = "0.#.#" # Replace with your desired version
 
   key_vault_resource_id = azurerm_key_vault.this.id
   name                  = "my-key"

--- a/modules/secret/README.md
+++ b/modules/secret/README.md
@@ -10,7 +10,8 @@ This sub-module can be called directly to add secrets to an existing key vault:
 
 ```terraform
 module "keyvault_secret" {
-  source = "Azure/avm-res-keyvault-vault/azurerm//modules/secret"
+  source  = "Azure/avm-res-keyvault-vault/azurerm//modules/secret"
+  version = "0.#.#" # Replace with your desired version
 
   key_vault_resource_id = azurerm_key_vault.this.id
   name                  = "my-secret"

--- a/modules/secret/README.md
+++ b/modules/secret/README.md
@@ -10,8 +10,7 @@ This sub-module can be called directly to add secrets to an existing key vault:
 
 ```terraform
 module "keyvault_secret" {
-  source  = "Azure/avm-res-keyvault-vault/azurerm//modules/secret"
-  version = "0.10.2"
+  source = "Azure/avm-res-keyvault-vault/azurerm//modules/secret"
 
   key_vault_resource_id = azurerm_key_vault.this.id
   name                  = "my-secret"

--- a/modules/secret/_header.md
+++ b/modules/secret/_header.md
@@ -8,7 +8,8 @@ This sub-module can be called directly to add secrets to an existing key vault:
 
 ```terraform
 module "keyvault_secret" {
-  source = "Azure/avm-res-keyvault-vault/azurerm//modules/secret"
+  source  = "Azure/avm-res-keyvault-vault/azurerm//modules/secret"
+  version = "0.#.#" # Replace with your desired version
 
   key_vault_resource_id = azurerm_key_vault.this.id
   name                  = "my-secret"

--- a/modules/secret/_header.md
+++ b/modules/secret/_header.md
@@ -8,8 +8,7 @@ This sub-module can be called directly to add secrets to an existing key vault:
 
 ```terraform
 module "keyvault_secret" {
-  source  = "Azure/avm-res-keyvault-vault/azurerm//modules/secret"
-  version = "0.10.2"
+  source = "Azure/avm-res-keyvault-vault/azurerm//modules/secret"
 
   key_vault_resource_id = azurerm_key_vault.this.id
   name                  = "my-secret"


### PR DESCRIPTION
Closes #312.

## The problem

PR #308 added registry usage examples to the header docs for both submodules, and each one pins `version = "0.10.2"`. `terraform-docs` copies `_header.md` verbatim into `README.md`, so the published docs carry that pin indefinitely. The moment we tag `0.10.3` the examples are wrong, and nothing in CI catches it — the docs still generate cleanly, they are just stale. It is a silent failure mode that only surfaces when a consumer copy-pastes an old version and wonders why they are missing a feature.

## The fix

Replace the concrete pin with a placeholder and a comment:

```terraform
module "keyvault_key" {
  source  = "Azure/avm-res-keyvault-vault/azurerm//modules/key"
  version = "0.#.#" # Replace with your desired version
```

This keeps `version` visible as part of the registry call pattern, in line with the stated best practice, while removing the thing that rots. A placeholder cannot go out of date at release time, so there is nothing for a release hook or a CI lint to keep in sync.

I originally proposed omitting `version` altogether, on the precedent that every other AVM Terraform module with submodules does that ([subnet](https://github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork/blob/main/modules/subnet/_header.md), [peering](https://github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork/blob/main/modules/peering/_header.md), [extension](https://github.com/Azure/terraform-azurerm-avm-res-compute-virtualmachine/blob/main/modules/extension/_header.md), [blob_service](https://github.com/Azure/terraform-azurerm-avm-res-storage-storageaccount/blob/main/modules/blob_service/_header.md)). Review preferred keeping the argument visible, and the placeholder suggested by @jaredfholgate is a better answer than either of the options I had been weighing — it satisfies the best-practice concern without reintroducing the drift.

It also beats the three approaches floated in #312. Rewriting the pin from a release hook would mean building new machinery, since releases here are a manual tag with no release workflow. A `~>` constraint only defers the problem — `~> 0.10` still goes stale at `0.11`. And a CI lint just guards a pin we would then have to keep bumping. A placeholder needs none of that.

## Tradeoff

The example block is no longer copy-paste-runnable as-is, because `0.#.#` is not a valid version constraint. I think that is the right call — it makes selecting a version an explicit decision for the consumer rather than one they inherit from whenever the docs were last regenerated — but it is a genuine behaviour change from what #308 shipped, so calling it out rather than burying it.

## Changes

- `modules/key/_header.md` and `modules/secret/_header.md`: `version = "0.10.2"` → `version = "0.#.#" # Replace with your desired version`
- Regenerated `modules/key/README.md` and `modules/secret/README.md` with `terraform-docs -c modules/.terraform-docs.yml`

Nothing under `examples/` is touched; the AVM dependency pins that SNFR2 governs (e.g. `avm-utl-regions` at `0.3.0` and `0.9.0`) are unchanged.

## Validation

- `terraform fmt -recursive -check` clean
- `terraform validate` at root succeeds
- `terraform test -test-directory=tests/unit` — 15 passed, 0 failed
