### PR TITLE
feat: add write-only secret value support

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ Description: A map of secrets to create on the Key Vault. The map key is deliber
 
 Supply role assignments in the same way as for `var.role_assignments`.
 
-> Note: the `value` of the secret is supplied via the `var.secrets_value` variable. Make sure to use the same map key.
+> Note: the `value` of the secret is supplied via the `var.secrets_value` variable, or via `var.secrets_value_wo` and `var.secrets_value_wo_version` for a write-only value. Make sure to use the same map key.
 
 Type:
 

--- a/README.md
+++ b/README.md
@@ -453,7 +453,28 @@ This is a separate variable to `var.secrets` because it is sensitive and therefo
 
 Type: `map(string)`
 
-Default: `null`
+Default: `{}`
+
+### <a name="input_secrets_value_wo"></a> [secrets\_value\_wo](#input\_secrets\_value\_wo)
+
+Description: A map of secret keys to values writable only.  
+The map key is the supplied input to `var.secrets`.  
+The map value is an object with the following attributes:
+- `value` - The value for the secret writable only.
+- `version` - The version of the secret writable only. Changing this updates the secret value.
+
+This is a separate variable to `var.secrets` because it is sensitive and therefore cannot be used in a `for_each` loop.
+
+Type:
+
+```hcl
+map(object({
+    value   = string
+    version = number
+  }))
+```
+
+Default: `{}`
 
 ### <a name="input_sku_name"></a> [sku\_name](#input\_sku\_name)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Module to deploy key vaults, keys and secrets in Azure.
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.11, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
 

--- a/README.md
+++ b/README.md
@@ -457,24 +457,27 @@ Default: `{}`
 
 ### <a name="input_secrets_value_wo"></a> [secrets\_value\_wo](#input\_secrets\_value\_wo)
 
-Description: A map of secret keys to values writable only.  
+Description: A map of secret keys to writable-only secret values.  
 The map key is the supplied input to `var.secrets`.  
-The map value is an object with the following attributes:
-- `value` - The value for the secret writable only.
-- `version` - The version of the secret writable only. Changing this updates the secret value.
+The map value is the writable-only secret value for that key.
 
-This is a separate variable to `var.secrets` because it is sensitive and therefore cannot be used in a `for_each` loop.
+Use `var.secrets_value_wo_version` with the same key to control updates when the writable-only value changes.
 
-Type:
+Type: `map(string)`
 
-```hcl
-map(object({
-    value   = string
-    version = number
-  }))
-```
+Default: `null`
 
-Default: `{}`
+### <a name="input_secrets_value_wo_version"></a> [secrets\_value\_wo\_version](#input\_secrets\_value\_wo\_version)
+
+Description: A map of secret keys to writable-only secret value versions.  
+The map key is the supplied input to `var.secrets`.  
+The map value is the version identifier for that secret value.
+
+Use the same key as `var.secrets_value_wo`; increment the version when the corresponding writable-only value changes to trigger a secret update.
+
+Type: `map(number)`
+
+Default: `null`
 
 ### <a name="input_sku_name"></a> [sku\_name](#input\_sku\_name)
 

--- a/examples/create-secret/README.md
+++ b/examples/create-secret/README.md
@@ -86,9 +86,18 @@ module "key_vault" {
     test_secret = {
       name = "test-secret"
     }
+    test_secret_wo = {
+      name = "test-secret-wo"
+    }
   }
   secrets_value = {
     test_secret = "secret-value"
+  }
+  secrets_value_wo = {
+    test_secret_wo = "secret-value-wo"
+  }
+  secrets_value_wo_version = {
+    test_secret_wo = 1
   }
   wait_for_rbac_before_secret_operations = {
     create = "60s"

--- a/examples/create-secret/README.md
+++ b/examples/create-secret/README.md
@@ -10,7 +10,7 @@ provider "azurerm" {
 }
 
 terraform {
-  required_version = ">= 1.9, < 2.0"
+  required_version = ">= 1.11, < 2.0"
 
   required_providers {
     azurerm = {
@@ -110,7 +110,7 @@ module "key_vault" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.11, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.81)
 

--- a/examples/create-secret/main.tf
+++ b/examples/create-secret/main.tf
@@ -3,7 +3,7 @@ provider "azurerm" {
 }
 
 terraform {
-  required_version = ">= 1.9, < 2.0"
+  required_version = ">= 1.11, < 2.0"
 
   required_providers {
     azurerm = {
@@ -87,10 +87,10 @@ module "key_vault" {
     test_secret = "secret-value"
   }
   secrets_value_wo = {
-    test_secret_wo = {
-      value   = "secret-value-wo"
-      version = 1
-    }
+    test_secret_wo = "secret-value-wo"
+  }
+  secrets_value_wo_version = {
+    test_secret_wo = 1
   }
   wait_for_rbac_before_secret_operations = {
     create = "60s"

--- a/examples/create-secret/main.tf
+++ b/examples/create-secret/main.tf
@@ -79,12 +79,15 @@ module "key_vault" {
     test_secret = {
       name = "test-secret"
     }
+    test_secret_wo = {
+      name = "test-secret-wo"
+    }
   }
   secrets_value = {
     test_secret = "secret-value"
   }
   secrets_value_wo = {
-    test_secret = {
+    test_secret_wo = {
       value   = "secret-value-wo"
       version = 1
     }

--- a/examples/create-secret/main.tf
+++ b/examples/create-secret/main.tf
@@ -83,6 +83,12 @@ module "key_vault" {
   secrets_value = {
     test_secret = "secret-value"
   }
+  secrets_value_wo = {
+    test_secret = {
+      value   = "secret-value-wo"
+      version = 1
+    }
+  }
   wait_for_rbac_before_secret_operations = {
     create = "60s"
   }

--- a/main.secrets.tf
+++ b/main.secrets.tf
@@ -5,8 +5,8 @@ module "secrets" {
   key_vault_resource_id = azurerm_key_vault.this.id
   name                  = each.value.name
   value                 = try(var.secrets_value[each.key], null)
-  value_wo              = try(var.secrets_value_wo[each.key].value, null)
-  value_wo_version      = try(var.secrets_value_wo[each.key].version, null)
+  value_wo              = try(var.secrets_value_wo[each.key], null)
+  value_wo_version      = try(var.secrets_value_wo_version[each.key], null)
   content_type          = each.value.content_type
   expiration_date       = each.value.expiration_date
   not_before_date       = each.value.not_before_date

--- a/main.secrets.tf
+++ b/main.secrets.tf
@@ -4,14 +4,14 @@ module "secrets" {
 
   key_vault_resource_id = azurerm_key_vault.this.id
   name                  = each.value.name
-  value                 = try(var.secrets_value[each.key], null)
-  value_wo              = try(var.secrets_value_wo[each.key], null)
-  value_wo_version      = try(var.secrets_value_wo_version[each.key], null)
   content_type          = each.value.content_type
   expiration_date       = each.value.expiration_date
   not_before_date       = each.value.not_before_date
   role_assignments      = each.value.role_assignments
   tags                  = each.value.tags
+  value                 = try(var.secrets_value[each.key], null)
+  value_wo              = try(var.secrets_value_wo[each.key], null)
+  value_wo_version      = try(var.secrets_value_wo_version[each.key], null)
 
   depends_on = [
     azurerm_private_endpoint.this,

--- a/main.secrets.tf
+++ b/main.secrets.tf
@@ -4,7 +4,9 @@ module "secrets" {
 
   key_vault_resource_id = azurerm_key_vault.this.id
   name                  = each.value.name
-  value                 = var.secrets_value[each.key]
+  value                 = try(var.secrets_value[each.key], null)
+  value_wo              = try(var.secrets_value_wo[each.key].value, null)
+  value_wo_version      = try(var.secrets_value_wo[each.key].version, null)
   content_type          = each.value.content_type
   expiration_date       = each.value.expiration_date
   not_before_date       = each.value.not_before_date

--- a/modules/secret/README.md
+++ b/modules/secret/README.md
@@ -64,12 +64,6 @@ Description: The name of the secret.
 
 Type: `string`
 
-### <a name="input_value"></a> [value](#input\_value)
-
-Description: The value for the secret.
-
-Type: `string`
-
 ## Optional Inputs
 
 The following input variables are optional (have default values):
@@ -133,6 +127,30 @@ Default: `{}`
 Description: The tags to assign to the secret.
 
 Type: `map(string)`
+
+Default: `null`
+
+### <a name="input_value"></a> [value](#input\_value)
+
+Description: The value for the secret. Must be set if `value_wo` is not set.
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_value_wo"></a> [value\_wo](#input\_value\_wo)
+
+Description: The value for the secret writable only. Must be set if `value` is not set.
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_value_wo_version"></a> [value\_wo\_version](#input\_value\_wo\_version)
+
+Description: The version of the secret writable only. Must be set if `value_wo` is not set.
+
+Type: `number`
 
 Default: `null`
 

--- a/modules/secret/README.md
+++ b/modules/secret/README.md
@@ -148,7 +148,7 @@ Default: `null`
 
 ### <a name="input_value_wo_version"></a> [value\_wo\_version](#input\_value\_wo\_version)
 
-Description: The version of the secret writable only. Must be set if `value_wo` is not set. Changing this updates the secret value.
+Description: The version of the secret writable only. Must be set if `value_wo` is set. Changing this updates the secret value.
 
 Type: `number`
 

--- a/modules/secret/README.md
+++ b/modules/secret/README.md
@@ -148,7 +148,7 @@ Default: `null`
 
 ### <a name="input_value_wo_version"></a> [value\_wo\_version](#input\_value\_wo\_version)
 
-Description: The version of the secret writable only. Must be set if `value_wo` is not set.
+Description: The version of the secret writable only. Must be set if `value_wo` is not set. Changing this updates the secret value.
 
 Type: `number`
 

--- a/modules/secret/README.md
+++ b/modules/secret/README.md
@@ -36,7 +36,7 @@ module "keyvault_secret" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.11, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.81, < 5.0)
 

--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -1,11 +1,13 @@
 resource "azurerm_key_vault_secret" "this" {
-  key_vault_id    = var.key_vault_resource_id
-  name            = var.name
-  content_type    = var.content_type
-  expiration_date = var.expiration_date
-  not_before_date = var.not_before_date
-  tags            = var.tags
-  value           = var.value
+  key_vault_id     = var.key_vault_resource_id
+  name             = var.name
+  content_type     = var.content_type
+  expiration_date  = var.expiration_date
+  not_before_date  = var.not_before_date
+  tags             = var.tags
+  value            = var.value
+  value_wo         = var.value_wo
+  value_wo_version = var.value_wo_version
 }
 
 resource "azurerm_role_assignment" "this" {

--- a/modules/secret/terraform.tf
+++ b/modules/secret/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.9, < 2.0"
+  required_version = ">= 1.11, < 2.0"
 
   required_providers {
     azurerm = {

--- a/modules/secret/variables.tf
+++ b/modules/secret/variables.tf
@@ -37,7 +37,7 @@ variable "value_wo" {
 
 variable "value_wo_version" {
   type        = number
-  description = "The version of the secret writable only. Must be set if `value_wo` is not set. Changing this updates the secret value."
+  description = "The version of the secret writable only. Must be set if `value_wo` is set. Changing this updates the secret value."
   default     = null
 }
 

--- a/modules/secret/variables.tf
+++ b/modules/secret/variables.tf
@@ -36,7 +36,7 @@ variable "value_wo" {
 
 variable "value_wo_version" {
   type        = number
-  description = "The version of the secret writable only. Must be set if `value_wo` is not set."
+  description = "The version of the secret writable only. Must be set if `value_wo` is not set. Changing this updates the secret value."
   default     = null
 }
 

--- a/modules/secret/variables.tf
+++ b/modules/secret/variables.tf
@@ -31,6 +31,7 @@ variable "value_wo" {
   type        = string
   description = "The value for the secret writable only. Must be set if `value` is not set."
   default     = null
+  ephemeral   = true
   sensitive   = true
 }
 

--- a/modules/secret/variables.tf
+++ b/modules/secret/variables.tf
@@ -22,8 +22,22 @@ variable "name" {
 
 variable "value" {
   type        = string
-  description = "The value for the secret."
+  description = "The value for the secret. Must be set if `value_wo` is not set."
+  default     = null
   sensitive   = true
+}
+
+variable "value_wo" {
+  type        = string
+  description = "The value for the secret writable only. Must be set if `value` is not set."
+  default     = null
+  sensitive   = true
+}
+
+variable "value_wo_version" {
+  type        = number
+  description = "The version of the secret writable only. Must be set if `value_wo` is not set."
+  default     = null
 }
 
 variable "content_type" {

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.9, < 2.0"
+  required_version = ">= 1.11, < 2.0"
 
   required_providers {
     azapi = {

--- a/tests/unit/secrets.tftest.hcl
+++ b/tests/unit/secrets.tftest.hcl
@@ -1,0 +1,85 @@
+mock_provider "azurerm" {}
+mock_provider "modtm" {}
+
+variables {
+  enable_telemetry    = false
+  resource_group_name = "test"
+  name                = "test"
+  location            = "eastus"
+  tenant_id           = "00000000-0000-0000-0000-000000000000"
+}
+
+run "secrets_plain_value" {
+  command = plan
+
+  variables {
+    secrets = {
+      plain = {
+        name = "plain-secret"
+      }
+    }
+    secrets_value = {
+      plain = "secret-value"
+    }
+  }
+}
+
+run "secrets_write_only_value" {
+  command = plan
+
+  variables {
+    secrets = {
+      wo = {
+        name = "wo-secret"
+      }
+    }
+    secrets_value_wo = {
+      wo = "secret-value-wo"
+    }
+    secrets_value_wo_version = {
+      wo = 1
+    }
+  }
+}
+
+run "secrets_plain_and_write_only_coexist" {
+  command = plan
+
+  variables {
+    secrets = {
+      plain = {
+        name = "plain-secret"
+      }
+      wo = {
+        name = "wo-secret"
+      }
+    }
+    secrets_value = {
+      plain = "secret-value"
+    }
+    secrets_value_wo = {
+      wo = "secret-value-wo"
+    }
+    secrets_value_wo_version = {
+      wo = 1
+    }
+  }
+}
+
+run "secrets_write_only_version_increment" {
+  command = plan
+
+  variables {
+    secrets = {
+      wo = {
+        name = "wo-secret"
+      }
+    }
+    secrets_value_wo = {
+      wo = "rotated-value"
+    }
+    secrets_value_wo_version = {
+      wo = 2
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -445,21 +445,28 @@ DESCRIPTION
 }
 
 variable "secrets_value_wo" {
-  type = map(object({
-    value   = string
-    version = number
-  }))
-  default     = {}
+  type        = map(string)
+  default     = null
   description = <<DESCRIPTION
-A map of secret keys to values writable only.
+A map of secret keys to writable-only secret values.
 The map key is the supplied input to `var.secrets`.
-The map value is an object with the following attributes:
-- `value` - The value for the secret writable only.
-- `version` - The version of the secret writable only. Changing this updates the secret value.
+The map value is the writable-only secret value for that key.
 
-This is a separate variable to `var.secrets` because it is sensitive and therefore cannot be used in a `for_each` loop.
+Use `var.secrets_value_wo_version` with the same key to control updates when the writable-only value changes.
 DESCRIPTION
   sensitive   = true
+}
+
+variable "secrets_value_wo_version" {
+  type        = map(number)
+  default     = null
+  description = <<DESCRIPTION
+A map of secret keys to writable-only secret value versions.
+The map key is the supplied input to `var.secrets`.
+The map value is the version identifier for that secret value.
+
+Use the same key as `var.secrets_value_wo`; increment the version when the corresponding writable-only value changes to trigger a secret update.
+DESCRIPTION
 }
 
 variable "sku_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -426,7 +426,7 @@ A map of secrets to create on the Key Vault. The map key is deliberately arbitra
 
 Supply role assignments in the same way as for `var.role_assignments`.
 
-> Note: the `value` of the secret is supplied via the `var.secrets_value` variable. Make sure to use the same map key.
+> Note: the `value` of the secret is supplied via the `var.secrets_value` variable, or via `var.secrets_value_wo` and `var.secrets_value_wo_version` for a write-only value. Make sure to use the same map key.
 DESCRIPTION
   nullable    = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -454,6 +454,7 @@ The map value is the writable-only secret value for that key.
 
 Use `var.secrets_value_wo_version` with the same key to control updates when the writable-only value changes.
 DESCRIPTION
+  ephemeral   = true
   sensitive   = true
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -433,11 +433,29 @@ DESCRIPTION
 
 variable "secrets_value" {
   type        = map(string)
-  default     = null
+  default     = {}
   description = <<DESCRIPTION
 A map of secret keys to values.
 The map key is the supplied input to `var.secrets`.
 The map value is the secret value.
+
+This is a separate variable to `var.secrets` because it is sensitive and therefore cannot be used in a `for_each` loop.
+DESCRIPTION
+  sensitive   = true
+}
+
+variable "secrets_value_wo" {
+  type = map(object({
+    value   = string
+    version = number
+  }))
+  default     = {}
+  description = <<DESCRIPTION
+A map of secret keys to values writable only.
+The map key is the supplied input to `var.secrets`.
+The map value is an object with the following attributes:
+- `value` - The value for the secret writable only.
+- `version` - The version of the secret writable only. Changing this updates the secret value.
 
 This is a separate variable to `var.secrets` because it is sensitive and therefore cannot be used in a `for_each` loop.
 DESCRIPTION

--- a/variables.tf
+++ b/variables.tf
@@ -454,8 +454,8 @@ The map value is the writable-only secret value for that key.
 
 Use `var.secrets_value_wo_version` with the same key to control updates when the writable-only value changes.
 DESCRIPTION
-  ephemeral   = true
   sensitive   = true
+  ephemeral   = true
 }
 
 variable "secrets_value_wo_version" {


### PR DESCRIPTION
Adds write-only secret value support to the Key Vault module, so secret values can be supplied without ever being persisted to Terraform state.

This carries the work from #266 by @phsmith. Their commits are cherry-picked here as-is with authorship preserved — that PR can't run CI where it sits, because `pr-check.yml` gates the managed workflow on `head.repo.fork == false`. Please leave #266 open; it isn't superseded and hasn't been retargeted.

Closes #271.

## What it adds

- `var.secrets_value_wo` and `var.secrets_value_wo_version` at the root, both keyed the same way as `var.secrets`.
- `value_wo` and `value_wo_version` on `modules/secret`.
- Coverage in `examples/create-secret`.

The value input is `ephemeral` at both the root and the submodule, which is required for ephemerality to propagate through the call chain. The version input is deliberately *not* ephemeral — it has to persist in state, since that's the only way a changed value becomes detectable when the value itself is never stored.

## Breaking: this raises the Terraform floor to `>= 1.11`

`required_version` goes from `>= 1.9, < 2.0` to `>= 1.11, < 2.0` in `terraform.tf`, `modules/secret/terraform.tf`, and the example. **Consumers on Terraform 1.9 or 1.10 will no longer be able to use this module**, whether or not they use write-only secrets.

I checked whether `1.11` is genuinely the floor rather than a convenient round number, and it is:

- Terraform **1.11.0** (2025-02-27) is the release that added the feature: "Add write-only attributes to resources. Providers can specify that certain attributes are write-only. They are not persisted in state." ([changelog](https://github.com/hashicorp/terraform/blob/v1.11/CHANGELOG.md), [hashicorp/terraform#36031](https://github.com/hashicorp/terraform/issues/36031))
- HashiCorp's SDKv2 documentation states it plainly: "Write-only arguments are only supported in Terraform v1.11 or higher."
- The azurerm provider's own contributor guide says the same, and its acceptance tests gate on `tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0")))`.

Terraform 1.10 gives you `ephemeral` input variables but not write-only *resource arguments*, and we need both. So there is no lower floor that works.

**There's also no way to make it opt-in.** I checked whether the bump could be scoped to `modules/secret`, leaving the root at `>= 1.9` for consumers who don't use write-only secrets. It can't: Terraform enforces a child module's `required_version` at `init` for every module present in the configuration, regardless of instance count. I confirmed that with a throwaway config — a child module with `for_each = {}` and an unsatisfiable constraint still fails:

```
Error: Unsupported Terraform Core version
  Module module.unused (from ./child) does not support Terraform version 1.15.8.
```

Since `main.secrets.tf` always instantiates `modules/secret`, the floor is effectively global. It's ship-with-the-floor or don't ship.

No provider bump is needed — `value_wo` landed in azurerm **4.23.0** ([CHANGELOG](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/CHANGELOG-v4.md), [hashicorp/terraform-provider-azurerm#28947](https://github.com/hashicorp/terraform-provider-azurerm/issues/28947)) and we already floor at `>= 4.81`.

### Versioning

We're pre-1.0 at `v0.10.2`. Per [SNFR17](https://azure.github.io/Azure-Verified-Modules/spec/SNFR17) and [SNFR18](https://azure.github.io/Azure-Verified-Modules/spec/SNFR18), breaking changes on a pre-1.0 module bump the **minor** version, so this should release as **`v0.11.0`** with the Terraform floor called out in the release notes. No major bump needed.

## Review notes

On top of @phsmith's commits I've added two things.

**A description fix.** `value_wo_version` read "Must be set if `value_wo` is not set", which is backwards. In the provider schema the two are mutually `RequiredWith`, so the version is required when `value_wo` *is* set. Supplying `value_wo` alone is the error case.

**Unit tests.** There was no coverage for the new path. `tests/unit/secrets.tftest.hcl` covers the plain path, the write-only path, both coexisting, and a version increment. 21 unit tests pass, up from 17.

Worth knowing what those tests can't assert: that the value is absent from state. Run blocks only see outputs, and the module rightly exposes no secret output. That guarantee comes from `value_wo` being `WriteOnly` in the provider schema, which means core never persists it; the tests lock in the wiring instead.

I also verified the misuse cases are all caught by the provider at plan time, so no unsafe combination is reachable:

| Input | Result |
| --- | --- |
| Both `secrets_value` and `secrets_value_wo` for one key | `only one of value,value_wo can be specified` |
| Neither set | `one of value,value_wo must be specified` |
| `value_wo` without a version | `all of value_wo,value_wo_version must be specified` |

That second row was my main concern, since `main.secrets.tf` now wraps the lookups in `try(..., null)` — but a valueless secret can't be created silently.

The errors surface against `modules/secret/main.tf` rather than the root variable, which is a little indirect. Root-level validation would give a friendlier message, but I'd treat that as follow-up polish rather than something to hold this on.

_Drafted by Claude Opus 5._
