### PR TITLE
fix: create management locks for private endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The following resources are used by this module:
 - [azurerm_key_vault.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) (resource)
 - [azurerm_key_vault_access_policy.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) (resource)
 - [azurerm_key_vault_certificate_contacts.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_certificate_contacts) (resource)
+- [azurerm_management_lock.private_endpoints](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
+- [azurerm_management_lock.private_endpoints_unmanaged_dns_zone_groups](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
 - [azurerm_management_lock.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
 - [azurerm_monitor_diagnostic_setting.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) (resource)
 - [azurerm_private_endpoint.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) (resource)
@@ -256,7 +258,10 @@ Default: `false`
 
 ### <a name="input_lock"></a> [lock](#input\_lock)
 
-Description: The lock level to apply to the Key Vault. Default is `None`. Possible values are `None`, `CanNotDelete`, and `ReadOnly`.
+Description: Controls the Resource Lock configuration for the Key Vault. Omit it, or set it to `null`, to create no lock.
+
+- `kind` - (Required) The type of lock. Possible values are `CanNotDelete` and `ReadOnly`.
+- `name` - (Optional) The name of the lock. One is generated from the Key Vault name if not set. Changing this forces the creation of a new resource.
 
 Type:
 
@@ -299,7 +304,9 @@ Description: A map of private endpoints to create on the Key Vault. The map key 
 
 - `name` - (Optional) The name of the private endpoint. One will be generated if not set.
 - `role_assignments` - (Optional) A map of role assignments to create on the private endpoint. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time. See `var.role_assignments` for more information.
-- `lock` - (Optional) The lock level to apply to the private endpoint. Default is `None`. Possible values are `None`, `CanNotDelete`, and `ReadOnly`.
+- `lock` - (Optional) The lock to apply to the private endpoint. Omit it, or set it to `null`, to create no lock.
+  - `kind` - (Required) The type of lock. Possible values are `CanNotDelete` and `ReadOnly`.
+  - `name` - (Optional) The name of the lock. One is generated from the private endpoint name if not set. Changing this forces the creation of a new resource.
 - `tags` - (Optional) A mapping of tags to assign to the private endpoint.
 - `subnet_resource_id` - The resource ID of the subnet to deploy the private endpoint in.
 - `private_dns_zone_group_name` - (Optional) The name of the private DNS zone group. One will be generated if not set.

--- a/main.private_endpoint.tf
+++ b/main.private_endpoint.tf
@@ -77,3 +77,27 @@ resource "azurerm_private_endpoint_application_security_group_association" "this
   application_security_group_id = each.value.asg_resource_id
   private_endpoint_id           = azurerm_private_endpoint.this[each.value.pe_key].id
 }
+
+# The lock for the PE resource when we are managing the private_dns_zone_group block:
+resource "azurerm_management_lock" "private_endpoints" {
+  for_each = { for k, v in var.private_endpoints : k => v if v.lock != null && var.private_endpoints_manage_dns_zone_group }
+
+  lock_level = each.value.lock.kind
+  name       = coalesce(each.value.lock.name, "lock-${azurerm_private_endpoint.this[each.key].name}")
+  scope      = azurerm_private_endpoint.this[each.key].id
+
+  # Terraform destroys a lock before the resources it depends on, so naming the
+  # association here keeps the lock from blocking its own removal.
+  depends_on = [azurerm_private_endpoint_application_security_group_association.this]
+}
+
+# The lock for the PE resource when we are managing **not** the private_dns_zone_group block, such as when using Azure Policy:
+resource "azurerm_management_lock" "private_endpoints_unmanaged_dns_zone_groups" {
+  for_each = { for k, v in var.private_endpoints : k => v if v.lock != null && !var.private_endpoints_manage_dns_zone_group }
+
+  lock_level = each.value.lock.kind
+  name       = coalesce(each.value.lock.name, "lock-${azurerm_private_endpoint.this_unmanaged_dns_zone_groups[each.key].name}")
+  scope      = azurerm_private_endpoint.this_unmanaged_dns_zone_groups[each.key].id
+
+  depends_on = [azurerm_private_endpoint_application_security_group_association.this]
+}

--- a/tests/unit/private_endpoint_locks.tftest.hcl
+++ b/tests/unit/private_endpoint_locks.tftest.hcl
@@ -1,0 +1,190 @@
+mock_provider "azurerm" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+mock_provider "time" {}
+
+variables {
+  enable_telemetry    = false
+  tenant_id           = "00000000-0000-0000-0000-000000000000"
+  name                = "keyvault"
+  location            = "eastus"
+  resource_group_name = "resource_group_name"
+}
+
+# A lock on an endpoint has to land on whichever private endpoint resource is
+# active, so both DNS zone group modes get the same coverage.
+run "lock_with_managed_dns_zone_group" {
+  command = plan
+
+  variables {
+    private_endpoints_manage_dns_zone_group = true
+
+    private_endpoints = {
+      pe1 = {
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource_group_name/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+        lock = {
+          kind = "CanNotDelete"
+        }
+      }
+    }
+  }
+
+  assert {
+    error_message = "Lock should be created for the managed private endpoint"
+    condition     = keys(azurerm_management_lock.private_endpoints) == ["pe1"]
+  }
+  assert {
+    error_message = "No lock should be created for the unmanaged private endpoint"
+    condition     = length(azurerm_management_lock.private_endpoints_unmanaged_dns_zone_groups) == 0
+  }
+  assert {
+    error_message = "Lock level should come from the lock kind"
+    condition     = azurerm_management_lock.private_endpoints["pe1"].lock_level == "CanNotDelete"
+  }
+  assert {
+    error_message = "Lock name should default to the generated private endpoint name"
+    condition     = azurerm_management_lock.private_endpoints["pe1"].name == "lock-pe-keyvault"
+  }
+}
+
+run "lock_with_unmanaged_dns_zone_group" {
+  command = plan
+
+  variables {
+    private_endpoints_manage_dns_zone_group = false
+
+    private_endpoints = {
+      pe1 = {
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource_group_name/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+        lock = {
+          kind = "ReadOnly"
+        }
+      }
+    }
+  }
+
+  assert {
+    error_message = "Lock should be created for the unmanaged private endpoint"
+    condition     = keys(azurerm_management_lock.private_endpoints_unmanaged_dns_zone_groups) == ["pe1"]
+  }
+  assert {
+    error_message = "No lock should be created for the managed private endpoint"
+    condition     = length(azurerm_management_lock.private_endpoints) == 0
+  }
+  assert {
+    error_message = "Lock level should come from the lock kind"
+    condition     = azurerm_management_lock.private_endpoints_unmanaged_dns_zone_groups["pe1"].lock_level == "ReadOnly"
+  }
+  assert {
+    error_message = "Lock name should default to the generated private endpoint name"
+    condition     = azurerm_management_lock.private_endpoints_unmanaged_dns_zone_groups["pe1"].name == "lock-pe-keyvault"
+  }
+}
+
+run "lock_name_override_and_custom_endpoint_name" {
+  command = plan
+
+  variables {
+    private_endpoints = {
+      named = {
+        name               = "pe-custom"
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource_group_name/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+        lock = {
+          kind = "CanNotDelete"
+          name = "my-lock"
+        }
+      }
+      derived = {
+        name               = "pe-derived"
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource_group_name/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+        lock = {
+          kind = "CanNotDelete"
+        }
+      }
+    }
+  }
+
+  assert {
+    error_message = "An explicit lock name should win over the generated one"
+    condition     = azurerm_management_lock.private_endpoints["named"].name == "my-lock"
+  }
+  assert {
+    error_message = "A generated lock name should follow the private endpoint name"
+    condition     = azurerm_management_lock.private_endpoints["derived"].name == "lock-pe-derived"
+  }
+}
+
+# Endpoints without a lock must not drag an unwanted lock along with them.
+run "endpoints_without_a_lock_get_none" {
+  command = plan
+
+  variables {
+    private_endpoints = {
+      locked = {
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource_group_name/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+        lock = {
+          kind = "CanNotDelete"
+        }
+      }
+      unlocked = {
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource_group_name/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+      }
+    }
+  }
+
+  assert {
+    error_message = "Only the endpoint that asked for a lock should get one"
+    condition     = keys(azurerm_management_lock.private_endpoints) == ["locked"]
+  }
+  assert {
+    error_message = "Both private endpoints should still be created"
+    condition     = length(azurerm_private_endpoint.this) == 2
+  }
+}
+
+run "no_private_endpoints_means_no_locks" {
+  command = plan
+
+  assert {
+    error_message = "No locks should be created without private endpoints"
+    condition     = length(azurerm_management_lock.private_endpoints) == 0
+  }
+  assert {
+    error_message = "No locks should be created without private endpoints"
+    condition     = length(azurerm_management_lock.private_endpoints_unmanaged_dns_zone_groups) == 0
+  }
+}
+
+run "lock_rejects_unknown_kind" {
+  command = plan
+
+  variables {
+    private_endpoints = {
+      pe1 = {
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource_group_name/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+        lock = {
+          kind = "None"
+        }
+      }
+    }
+  }
+
+  expect_failures = [var.private_endpoints]
+}
+
+run "lock_kind_is_case_sensitive" {
+  command = plan
+
+  variables {
+    private_endpoints = {
+      pe1 = {
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource_group_name/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+        lock = {
+          kind = "cannotdelete"
+        }
+      }
+    }
+  }
+
+  expect_failures = [var.private_endpoints]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -258,7 +258,12 @@ variable "lock" {
     name = optional(string, null)
   })
   default     = null
-  description = "The lock level to apply to the Key Vault. Default is `None`. Possible values are `None`, `CanNotDelete`, and `ReadOnly`."
+  description = <<DESCRIPTION
+Controls the Resource Lock configuration for the Key Vault. Omit it, or set it to `null`, to create no lock.
+
+- `kind` - (Required) The type of lock. Possible values are `CanNotDelete` and `ReadOnly`.
+- `name` - (Optional) The name of the lock. One is generated from the Key Vault name if not set. Changing this forces the creation of a new resource.
+DESCRIPTION
 
   validation {
     condition     = var.lock != null ? contains(["CanNotDelete", "ReadOnly"], var.lock.kind) : true
@@ -332,7 +337,9 @@ A map of private endpoints to create on the Key Vault. The map key is deliberate
 
 - `name` - (Optional) The name of the private endpoint. One will be generated if not set.
 - `role_assignments` - (Optional) A map of role assignments to create on the private endpoint. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time. See `var.role_assignments` for more information.
-- `lock` - (Optional) The lock level to apply to the private endpoint. Default is `None`. Possible values are `None`, `CanNotDelete`, and `ReadOnly`.
+- `lock` - (Optional) The lock to apply to the private endpoint. Omit it, or set it to `null`, to create no lock.
+  - `kind` - (Required) The type of lock. Possible values are `CanNotDelete` and `ReadOnly`.
+  - `name` - (Optional) The name of the lock. One is generated from the private endpoint name if not set. Changing this forces the creation of a new resource.
 - `tags` - (Optional) A mapping of tags to assign to the private endpoint.
 - `subnet_resource_id` - The resource ID of the subnet to deploy the private endpoint in.
 - `private_dns_zone_group_name` - (Optional) The name of the private DNS zone group. One will be generated if not set.
@@ -347,6 +354,11 @@ A map of private endpoints to create on the Key Vault. The map key is deliberate
   - `private_ip_address` - The private IP address of the IP configuration.
 DESCRIPTION
   nullable    = false
+
+  validation {
+    condition     = alltrue([for _, v in var.private_endpoints : v.lock == null ? true : contains(["CanNotDelete", "ReadOnly"], v.lock.kind)])
+    error_message = "Lock kind must be either `\"CanNotDelete\"` or `\"ReadOnly\"`."
+  }
 }
 
 variable "private_endpoints_manage_dns_zone_group" {


### PR DESCRIPTION
## What's wrong

`var.private_endpoints` takes a per-endpoint `lock` object, and the variable description explains what the values mean. Nothing in the module ever read it.

The only `azurerm_management_lock` on `main` guards the Key Vault itself. So anyone who set a lock on a private endpoint got no lock, and got no warning either. The input was accepted, documented, and silently dropped.

Fixes #235

## What changed

**`main.private_endpoint.tf`** — added the missing locks. There are two private endpoint resources, split on `private_endpoints_manage_dns_zone_group`, so there are two lock resources with strictly complementary `for_each` maps to match. Each map also drops endpoints that set no lock:

```hcl
for_each = { for k, v in var.private_endpoints : k => v if v.lock != null && var.private_endpoints_manage_dns_zone_group }
```

The lock name falls back to `lock-<private endpoint name>`, which mirrors how the vault lock builds its own default from `var.name`.

**Destroy order.** I read #230 first so this doesn't repeat that mistake. The `scope` reference already makes each lock depend on its endpoint, so Terraform removes the lock first and the endpoint second — the right way round. The explicit `depends_on` extends that to the application security group association, whose removal an active lock would otherwise block. Note this doesn't fix #230, which is about locks a consumer applies outside the module.

**`variables.tf`** — both `lock` descriptions claimed `None` was a possible value. It never was: the vault validation has only ever allowed `CanNotDelete` and `ReadOnly`. So I corrected both descriptions and added the same validation to the private endpoint lock, so a bad `kind` fails at plan time rather than at apply.

**`README.md`** — regenerated with the repo's own `.terraform-docs.yml`.

## On the AVM spec

The Terraform interfaces spec does prescribe a shape, and the existing vault-level variable already matches it — same `kind`/`name` object, same `contains(["CanNotDelete", "ReadOnly"], ...)` validation, same error message. I copied that rather than inventing anything. The spec's canonical description lists only those two values, which is what settled the `None` question.

Two things worth flagging from the same section:

- It says locks **SHOULD** be settable on child resources, which is what this PR delivers.
- It also says locks **MUST** propagate automatically to cross-referenced resources when the primary resource is locked — and it uses Key Vault plus private endpoints as the worked example. This module doesn't do that. I left it alone on purpose: propagation would start creating locks for existing consumers who never asked for them, and could break their destroys. That deserves its own issue and its own opt-out variable.

## Testing

`terraform test -test-directory=tests/unit` goes from **21 passed** to **28 passed**, 0 failed.

New file `tests/unit/private_endpoint_locks.tftest.hcl` covers both DNS zone group modes, the generated lock name, an explicit name override, endpoints that mix locked with unlocked, the empty case, and both validation rejections (including `None`, the value the old docs advertised). I gave it its own filename so it won't collide with #320, which adds `private_endpoints.tftest.hcl`.

No example change. The spec itself warns that locks make destroys flaky through eventual consistency, and an e2e run costs a real deployment, so the plan-level coverage earns its keep better here.

`terraform fmt -recursive -check` and `terraform validate` both clean.

_Drafted by Claude Opus 5._
