### PR TITLE
fix: use current Key Vault RBAC argument

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_key_vault" "this" {
   resource_group_name             = var.resource_group_name
   sku_name                        = var.sku_name
   tenant_id                       = var.tenant_id
-  enable_rbac_authorization       = !var.legacy_access_policies_enabled
+  rbac_authorization_enabled      = !var.legacy_access_policies_enabled
   enabled_for_deployment          = var.enabled_for_deployment
   enabled_for_disk_encryption     = var.enabled_for_disk_encryption
   enabled_for_template_deployment = var.enabled_for_template_deployment

--- a/main.tf
+++ b/main.tf
@@ -4,12 +4,12 @@ resource "azurerm_key_vault" "this" {
   resource_group_name             = var.resource_group_name
   sku_name                        = var.sku_name
   tenant_id                       = var.tenant_id
-  rbac_authorization_enabled      = !var.legacy_access_policies_enabled
   enabled_for_deployment          = var.enabled_for_deployment
   enabled_for_disk_encryption     = var.enabled_for_disk_encryption
   enabled_for_template_deployment = var.enabled_for_template_deployment
   public_network_access_enabled   = var.public_network_access_enabled
   purge_protection_enabled        = var.purge_protection_enabled
+  rbac_authorization_enabled      = !var.legacy_access_policies_enabled
   soft_delete_retention_days      = var.soft_delete_retention_days
   tags                            = var.tags
 


### PR DESCRIPTION
## Summary

- Replace deprecated `enable_rbac_authorization` with `rbac_authorization_enabled` on `azurerm_key_vault.this`.

- Leave the module input `legacy_access_policies_enabled` unchanged; this only updates the provider-side argument name.

This does not need a provider floor bump. #315 already raised the module to `azurerm >= 4.81, < 5.0`, and `rbac_authorization_enabled` was introduced in AzureRM v4.42.0.

Closes #254


## Validation

- `terraform fmt -check -recursive`

- `terraform validate`

- `terraform test -test-directory=tests/unit` (`21 passed, 0 failed`)
- Regenerated docs with `terraform-docs -c .terraform-docs.yml .`; `README.md` did not drift.



_Drafted by GPT-5.5._




