### PR TITLE
test: add temporary release notes config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,28 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies
+      - github_actions
+    authors:
+      - dependabot[bot]
+      - azure-verified-modules[bot]
+  categories:
+    - title: Features
+      labels:
+        - "Type: Feature Request :heavy_plus_sign:"
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - "Type: Bug :bug:"
+        - bug
+    - title: Documentation
+      labels:
+        - "Type: Documentation :page_facing_up:"
+        - documentation
+    - title: CI and Hygiene
+      labels:
+        - "Type: CI :rocket:"
+        - "Type: Hygiene :broom:"
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## Summary

Adds `.github/release.yml` directly to this repo so we can live-test GitHub generated release notes for `v0.11.0` before the AVM managed-file version lands and syncs here.

This is intentional temporary drift from AVM managed files. The source change is also open in `Azure/azure-verified-modules-managed-files`:

- Issue: https://github.com/Azure/azure-verified-modules-managed-files/issues/13
- PR: https://github.com/Azure/azure-verified-modules-managed-files/pull/14

## Validation

- Parsed `.github/release.yml` with Ruby `YAML.load_file`.

## Follow-up

After this lands, regenerate the `v0.11.0` draft release notes and confirm the bot/chore noise drops out. Once the managed-file PR is merged and syncs back, this file should converge with the managed source.

_Drafted by GPT-5.5._